### PR TITLE
Added Target_link_libraries for myplugins

### DIFF
--- a/yolov5/CMakeLists.txt
+++ b/yolov5/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(yolov5 nvinfer)
 target_link_libraries(yolov5 cudart)
 target_link_libraries(yolov5 myplugins)
 target_link_libraries(yolov5 ${OpenCV_LIBS})
+target_link_libraries(myplugins nvinfer cudart)
 
 add_definitions(-O2 -pthread)
 


### PR DESCRIPTION
Based on @philipp-schmidt fix on his repository, https://github.com/wang-xinyu/tensorrtx/issues/139#issuecomment-674698203 I've added the link libraries to make sure that the plugin importation works well in Python TensorRT API.

The same will probably have to be done for all other implementations in this repository.