### PR TITLE
fix yolov3 build error

### DIFF
--- a/yolov3/CMakeLists.txt
+++ b/yolov3/CMakeLists.txt
@@ -19,14 +19,14 @@ link_directories(/usr/local/cuda/lib64)
 include_directories(/usr/include/x86_64-linux-gnu/)
 link_directories(/usr/lib/x86_64-linux-gnu/)
 
+find_package(OpenCV)
+include_directories(OpenCV_INCLUDE_DIRS)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Ofast -Wfatal-errors -D_MWAITXINTRIN_H_INCLUDED")
 
 #cuda_add_library(leaky ${PROJECT_SOURCE_DIR}/leaky.cu)
 cuda_add_library(yololayer SHARED ${PROJECT_SOURCE_DIR}/yololayer.cu)
-target_link_libraries(yololayer nvinfer cudart)
-
-find_package(OpenCV)
-include_directories(OpenCV_INCLUDE_DIRS)
+target_link_libraries(yololayer nvinfer cudart ${OpenCV_LIBS})
 
 add_executable(yolov3 ${PROJECT_SOURCE_DIR}/calibrator.cpp ${PROJECT_SOURCE_DIR}/yolov3.cpp)
 target_link_libraries(yolov3 nvinfer)


### PR DESCRIPTION
fix:
```
[ 20%] Building NVCC (Device) object CMakeFiles/yololayer.dir/yololayer_generated_yololayer.cu.o
In file included from //yolov3/yololayer.cu:2:0:
//yolov3/utils.h:9:10: fatal error: opencv2/opencv.hpp: No such file or directory
 #include <opencv2/opencv.hpp>
          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
CMake Error at yololayer_generated_yololayer.cu.o.Debug.cmake:219 (message):
  Error generating
  //tensorrtx/yolov3/build/CMakeFiles/yololayer.dir//./yololayer_generated_yololayer.cu.o


CMakeFiles/yololayer.dir/build.make:63: recipe for target 'CMakeFiles/yololayer.dir/yololayer_generated_yololayer.cu.o' failed
make[2]: *** [CMakeFiles/yololayer.dir/yololayer_generated_yololayer.cu.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/yololayer.dir/all' failed
make[1]: *** [CMakeFiles/yololayer.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2

```