### PR TITLE
Fix dockerfile bionic opencv 3.4 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ ARG CUDA="10"
 
 FROM hakuyyf/tensorrtx:trt${TENSORRT}_cuda${CUDA}
 
+# Get opencv 3.4 for bionic based images
+RUN rm /etc/apt/sources.list.d/timsc-ubuntu-opencv-3_3-bionic.list
+RUN rm /etc/apt/sources.list.d/timsc-ubuntu-opencv-3_3-bionic.list.save
+RUN add-apt-repository -y ppa:timsc/opencv-3.4
+
 RUN apt-get update
 
 # git clone tensorrtx

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN rm /etc/apt/sources.list.d/timsc-ubuntu-opencv-3_3-bionic.list.save
 RUN add-apt-repository -y ppa:timsc/opencv-3.4
 
 RUN apt-get update
-RUN apt-get install -y libopencv-dev libopencv-dnn-dev libopencv-shape3.4
+RUN apt-get install -y libopencv-dev libopencv-dnn-dev libopencv-shape3.4-dbg
 
 # git clone tensorrtx
 RUN git clone https://github.com/wang-xinyu/tensorrtx.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN rm /etc/apt/sources.list.d/timsc-ubuntu-opencv-3_3-bionic.list.save
 RUN add-apt-repository -y ppa:timsc/opencv-3.4
 
 RUN apt-get update
+RUN apt-get install -y libopencv-dev libopencv-dnn-dev libopencv-shape3.4
 
 # git clone tensorrtx
 RUN git clone https://github.com/wang-xinyu/tensorrtx.git


### PR DESCRIPTION
Building the Dockerfile out-of-the-box will result in an error:

```
E: The repository 'http://ppa.launchpad.net/timsc/opencv-3.3/ubuntu bionic Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
The command '/bin/sh -c apt-get update' returned a non-zero code: 100
```

This is because the source image `hakuyyf/tensorrtx` has the following repository added to its software sources `http://ppa.launchpad.net/timsc/opencv-3.3/ubuntu bionic Release` but this repository does not support ubuntu Bionic.

Since I can't change the original image, I'm submitting a fix which will replace the `opencv-3.3` ppa by an `opencv-3.4` ppa maintained by the same person, but which does support bionic.

In this way the Dockerfile runs for me


I have only tested yolov4, so we might have to check if it breaks anything

EDIT: I have made a script to test compilation success, this is the current status:


arcface x
dbnet - cuda runtime api
hrnet - cuda runtime api
inceptionv3 x
mnasnet x
mobilenetv3 x
resnet x
retinafaceAntiCov x
shufflenetv2 x
ufld - cuda runtime api
vgg x
yolov3-spp x
yolov4 x
alexnet x
crnn x
googlenet x
ibnnet x
lenet x
mobilenetv2 x
psenet - error: 'addConvRelu' was not declared in this scope
retinaface x
senet x
squeezenet x
unet - cuda runtime api
yolov3 x
yolov3-tiny x
yolov5 x

An x means it compiled. 4 modules fail to compile citing a cuda runtime api error not found, 1 fails on addConvRelu. I think the cuda runtime is quick fix (will look at it later) but the addConvRelu looks like a code specific error, not environment.