### PR TITLE
Another way to build yolov5 engines

### DIFF
--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -46,7 +46,9 @@ mkdir build
 cd build
 cmake ..
 make
-sudo ./yolov5 -s             // serialize model to plan file i.e. 'yolov5s.engine'
+sudo ./yolov5 -s 0.33 0.50   // serialize yolov5s model to plan file i.e. 'yolov5.engine'
+sudo ./yolov5 -s 0.67 0.75   // serialize yolov5m model to plan file i.e. 'yolov5.engine'
+sudo ./yolov5 -s 0.17 0.25   // serialize your own yolov5 model with depth_multiple and width_multiple which you set in '.yaml' file when training the model.
 sudo ./yolov5 -d  ../samples // deserialize plan file and run inference, the images in samples will be processed.
 ```
 

--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -48,7 +48,9 @@ cmake ..
 make
 sudo ./yolov5 -s 0.33 0.50   // serialize yolov5s model to plan file i.e. 'yolov5.engine'
 sudo ./yolov5 -s 0.67 0.75   // serialize yolov5m model to plan file i.e. 'yolov5.engine'
-sudo ./yolov5 -s 0.17 0.25   // serialize your own yolov5 model with depth_multiple and width_multiple which you set in '.yaml' file when training the model.
+sudo ./yolov5 -s 1.0 1.0   // serialize yolov5l model to plan file i.e. 'yolov5.engine'
+sudo ./yolov5 -s 1.33 1.25   // serialize yolov5x model to plan file i.e. 'yolov5.engine'
+sudo ./yolov5 -s 0.17 0.25   // serialize your own yolov5 model with depth_multiple and width_multiple which you set in '.yaml' file when training the model. i.e. depth = 0.17, width = 0.25
 sudo ./yolov5 -d  ../samples // deserialize plan file and run inference, the images in samples will be processed.
 ```
 


### PR DESCRIPTION
Hello, thank you for your excellent codes! When I use your repo to deploy my yolov5 model, I found that I can not build engine because I use none of the models given in https://github.com/ultralytics/yolov5. My models, for instance, have depth_multiple 0.17, width_multiple 0.25, (0.12, 0.17), (0.25,0.33), (0.40,0.67), which are not s, m, l or x. Besides, writing 4 functions for s, m, l and x respectively may be a little hard to update once the yolov5 5.0 changes its depth and width for example. 

So I write a function 'build_engine' to build all the yolov5 engines. I have tried on my jetson nano and could build engines from different yolov5 model successfully. 

I will be happy if this PR helps!