### PR TITLE
Update yolov5.cpp

### DIFF
--- a/yolov5/yolov5.cpp
+++ b/yolov5/yolov5.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
     }
 
     // prepare input data ---------------------------
-    static float data[BATCH_SIZE * 3 * INPUT_H * INPUT_W];
+    static float* data = new float[BATCH_SIZE * 3 * INPUT_H * INPUT_W];
     //for (int i = 0; i < 3 * INPUT_H * INPUT_W; i++)
     //    data[i] = 1.0;
     static float prob[BATCH_SIZE * OUTPUT_SIZE];
@@ -323,7 +323,7 @@ int main(int argc, char** argv) {
     context->destroy();
     engine->destroy();
     runtime->destroy();
-
+    delete[] data; 
     // Print histogram of the output distribution
     //std::cout << "\nOutput:\n\n";
     //for (unsigned int i = 0; i < OUTPUT_SIZE; i++)


### PR DESCRIPTION
Runtime error for input image sizes greater than 832x832 due to stack overflow
Modifying data array instantiation to allocate memory from heap instead of stack to allow for larger input sizes