### PR TITLE
Improvements

### DIFF
--- a/yolov3-spp/gen_wts.py
+++ b/yolov3-spp/gen_wts.py
@@ -1,18 +1,29 @@
 import struct
 import sys
+import os
 import torch
 from models import Darknet
 from utils.utils import torch_utils
 
 
 model = Darknet('cfg/yolov3-spp.cfg', (416, 416))
-weights = sys.argv[1]
+weights_file = sys.argv[1]
 dev = '0'
 device = torch_utils.select_device(dev)
-model.load_state_dict(torch.load(weights, map_location=device)['model'])
+model.load_state_dict(torch.load(weights_file, map_location=device)['model'])
+
+if len(sys.argv) > 2:
+    if os.path.isdir(sys.argv[2]):
+        wts_file = os.path.join(
+            sys.argv[2],
+            os.path.splitext(os.path.basename(weights_file))[0] + '.wts')
+    else:
+        wts_file = sys.argv[2]
+else:
+    wts_file = os.path.splitext(weights_file)[0] + '.wts'
 
 
-with open('yolov3-spp_ultralytics68.wts', 'w') as f:
+with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))
     for k, v in model.state_dict().items():
         vr = v.reshape(-1).cpu().numpy()

--- a/yolov3-spp/gen_wts.py
+++ b/yolov3-spp/gen_wts.py
@@ -1,7 +1,9 @@
 import struct
 import sys
-from models import *
-from utils.utils import *
+import torch
+from models import Darknet
+from utils.utils import torch_utils
+
 
 model = Darknet('cfg/yolov3-spp.cfg', (416, 416))
 weights = sys.argv[1]

--- a/yolov3-spp/gen_wts.py
+++ b/yolov3-spp/gen_wts.py
@@ -30,6 +30,6 @@ with open(wts_file, 'w') as f:
         f.write('{} {} '.format(k, len(vr)))
         for vv in vr:
             f.write(' ')
-            f.write(struct.pack('>f',float(vv)).hex())
+            f.write(struct.pack('>f', float(vv)).hex())
         f.write('\n')
 

--- a/yolov3-spp/yolov3-spp.cpp
+++ b/yolov3-spp/yolov3-spp.cpp
@@ -215,7 +215,7 @@ ICudaEngine* createEngine(unsigned int maxBatchSize, IBuilder* builder, IBuilder
     ITensor* data = network->addInput(INPUT_BLOB_NAME, dt, Dims4{1, 3, -1, -1});
     assert(data);
 
-    std::map<std::string, Weights> weightMap = loadWeights("../yolov3-spp_ultralytics68.wts");
+    std::map<std::string, Weights> weightMap = loadWeights("../yolov3-spp.wts");
     Weights emptywts{DataType::kFLOAT, nullptr, 0};
 
     // Yeah I am stupid, I just want to expand the complete arch of darknet..

--- a/yolov3-tiny/gen_wts.py
+++ b/yolov3-tiny/gen_wts.py
@@ -1,27 +1,38 @@
 import struct
 import sys
+import os
 import torch
 from models import Darknet, load_darknet_weights
 from utils.utils import torch_utils
 
 
 model = Darknet('cfg/yolov3-tiny.cfg', (608, 608))
-weights = sys.argv[1]
+weights_file = sys.argv[1]
 device = torch_utils.select_device('0')
-if weights.endswith('.pt'):  # pytorch format
-    model.load_state_dict(torch.load(weights, map_location=device)['model'])
+if weights_file.endswith('.pt'):  # pytorch format
+    model.load_state_dict(torch.load(weights_file, map_location=device)['model'])
 else:  # darknet format
-    load_darknet_weights(model, weights)
+    load_darknet_weights(model, weights_file)
 model = model.eval()
 
+if len(sys.argv) > 2:
+    if os.path.isdir(sys.argv[2]):
+        wts_file = os.path.join(
+            sys.argv[2],
+            os.path.splitext(os.path.basename(weights_file))[0] + '.wts')
+    else:
+        wts_file = sys.argv[2]
+else:
+    wts_file = os.path.splitext(weights_file)[0] + '.wts'
 
-with open('yolov3-tiny.wts', 'w') as f:
+
+with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))
     for k, v in model.state_dict().items():
         vr = v.reshape(-1).cpu().numpy()
         f.write('{} {} '.format(k, len(vr)))
         for vv in vr:
             f.write(' ')
-            f.write(struct.pack('>f',float(vv)).hex())
+            f.write(struct.pack('>f', float(vv)).hex())
         f.write('\n')
 

--- a/yolov3-tiny/gen_wts.py
+++ b/yolov3-tiny/gen_wts.py
@@ -1,7 +1,9 @@
 import struct
 import sys
-from models import *
-from utils.utils import *
+import torch
+from models import Darknet, load_darknet_weights
+from utils.utils import torch_utils
+
 
 model = Darknet('cfg/yolov3-tiny.cfg', (608, 608))
 weights = sys.argv[1]
@@ -11,6 +13,7 @@ if weights.endswith('.pt'):  # pytorch format
 else:  # darknet format
     load_darknet_weights(model, weights)
 model = model.eval()
+
 
 with open('yolov3-tiny.wts', 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))

--- a/yolov3/gen_wts.py
+++ b/yolov3/gen_wts.py
@@ -1,18 +1,20 @@
 import struct
 import sys
+import os
 from models import *
 from utils.utils import *
 
 model = Darknet('cfg/yolov3.cfg', (608, 608))
-weights = sys.argv[1]
+weights_file = sys.argv[1]
 device = torch_utils.select_device('0')
-if weights.endswith('.pt'):  # pytorch format
-    model.load_state_dict(torch.load(weights, map_location=device)['model'])
+if weights_file.endswith('.pt'):  # pytorch format
+    model.load_state_dict(torch.load(weights_file, map_location=device)['model'])
 else:  # darknet format
-    load_darknet_weights(model, weights)
+    load_darknet_weights(model, weights_file)
 model = model.eval()
+wts_file = sys.argv[2] if len(sys.argv) > 2 else os.path.splitext(weights_file)[0] + '.wts'
 
-with open('yolov3.wts', 'w') as f:
+with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))
     for k, v in model.state_dict().items():
         vr = v.reshape(-1).cpu().numpy()

--- a/yolov3/gen_wts.py
+++ b/yolov3/gen_wts.py
@@ -1,8 +1,10 @@
 import struct
 import sys
 import os
-from models import *
-from utils.utils import *
+import torch
+from models import Darknet, load_darknet_weights
+from utils import torch_utils
+
 
 model = Darknet('cfg/yolov3.cfg', (608, 608))
 weights_file = sys.argv[1]
@@ -12,7 +14,16 @@ if weights_file.endswith('.pt'):  # pytorch format
 else:  # darknet format
     load_darknet_weights(model, weights_file)
 model = model.eval()
-wts_file = sys.argv[2] if len(sys.argv) > 2 else os.path.splitext(weights_file)[0] + '.wts'
+
+if len(sys.argv) > 2:
+    if os.path.isdir(sys.argv[2]):
+        wts_file = os.path.join(
+            sys.argv[2],
+            os.path.splitext(os.path.basename(weights_file))[0] + '.wts')
+    else:
+        wts_file = sys.argv[2]
+else:
+    wts_file = os.path.splitext(weights_file)[0] + '.wts'
 
 with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))

--- a/yolov3/gen_wts.py
+++ b/yolov3/gen_wts.py
@@ -25,6 +25,7 @@ if len(sys.argv) > 2:
 else:
     wts_file = os.path.splitext(weights_file)[0] + '.wts'
 
+
 with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))
     for k, v in model.state_dict().items():

--- a/yolov3/gen_wts.py
+++ b/yolov3/gen_wts.py
@@ -33,6 +33,6 @@ with open(wts_file, 'w') as f:
         f.write('{} {} '.format(k, len(vr)))
         for vv in vr:
             f.write(' ')
-            f.write(struct.pack('>f',float(vv)).hex())
+            f.write(struct.pack('>f', float(vv)).hex())
         f.write('\n')
 

--- a/yolov5/gen_wts.py
+++ b/yolov5/gen_wts.py
@@ -1,6 +1,7 @@
 import torch
 import struct
 import sys
+import os
 from utils.torch_utils import select_device
 
 # Initialize
@@ -9,8 +10,9 @@ pt_file = sys.argv[1]
 # Load model
 model = torch.load(pt_file, map_location=device)['model'].float()  # load to FP32
 model.to(device).eval()
+wts_file = sys.argv[2] if len(sys.argv) > 2 else os.path.splitext(pt_file)[0] + '.wts'
 
-with open(pt_file.split('.')[0] + '.wts', 'w') as f:
+with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))
     for k, v in model.state_dict().items():
         vr = v.reshape(-1).cpu().numpy()

--- a/yolov5/gen_wts.py
+++ b/yolov5/gen_wts.py
@@ -4,13 +4,24 @@ import sys
 import os
 from utils.torch_utils import select_device
 
+
 # Initialize
 device = select_device('cpu')
 pt_file = sys.argv[1]
 # Load model
 model = torch.load(pt_file, map_location=device)['model'].float()  # load to FP32
 model.to(device).eval()
-wts_file = sys.argv[2] if len(sys.argv) > 2 else os.path.splitext(pt_file)[0] + '.wts'
+
+if len(sys.argv) > 2:
+    if os.path.isdir(sys.argv[2]):
+        wts_file = os.path.join(
+            sys.argv[2],
+            os.path.splitext(os.path.basename(pt_file))[0] + '.wts')
+    else:
+        wts_file = sys.argv[2]
+else:
+    wts_file = os.path.splitext(pt_file)[0] + '.wts'
+
 
 with open(wts_file, 'w') as f:
     f.write('{}\n'.format(len(model.state_dict().keys())))

--- a/yolov5/gen_wts.py
+++ b/yolov5/gen_wts.py
@@ -30,5 +30,5 @@ with open(wts_file, 'w') as f:
         f.write('{} {} '.format(k, len(vr)))
         for vv in vr:
             f.write(' ')
-            f.write(struct.pack('>f',float(vv)).hex())
+            f.write(struct.pack('>f', float(vv)).hex())
         f.write('\n')


### PR DESCRIPTION
*yolov3*s and *yolov5*.

- Fix imports
- Output file

    - Had to build the engines. Personally, I don't like to move files around (intra / inter repository). Added the possibility of specifying out file (*dir*). Of course, not all corner cases are handled, but handling them would probably introduce more code than the useful piece
    - Removed the suffix for *SPP*  (should it be added back?)
    -  *.cpp* sources could probably improved as well, but I guess *yolov3*s are only used in exceptional cases (because of *v5*)
    - Also works the way it was used before (backward compatibility - avoid breaking (possible) automation scripts)