### PR TITLE
A pure numpy version for yolov5_trt.py

### DIFF
--- a/hrnet/hrnet-semantic-segmentation/hrnet_trt.py
+++ b/hrnet/hrnet-semantic-segmentation/hrnet_trt.py
@@ -1,0 +1,217 @@
+"""
+An example that uses TensorRT's Python api to make inferences for hrnet.
+"""
+import os
+import shutil
+import random
+import sys
+import threading
+import time
+import cv2
+import numpy as np
+import pycuda.autoinit
+import pycuda.driver as cuda
+import tensorrt as trt
+from imgaug import augmenters as iaa
+
+def get_img_path_batches(batch_size, img_dir):
+    ret = []
+    batch = []
+    for root, dirs, files in os.walk(img_dir):
+        for name in files:
+            if len(batch) == batch_size:
+                ret.append(batch)
+                batch = []
+            batch.append(os.path.join(root, name))
+    if len(batch) > 0:
+        ret.append(batch)
+    return ret
+
+class Hrnet_TRT(object):
+    """
+    description: A Hrnet class that warps TensorRT ops, preprocess and postprocess ops.
+    """
+
+    def __init__(self, engine_file_path):
+        # Create a Context on this device,
+        self.cfx = cuda.Device(0).make_context()
+        stream = cuda.Stream()
+        runtime = trt.Runtime(trt.Logger(trt.Logger.INFO))
+        assert runtime
+        
+        # Deserialize the engine from file
+        with open(engine_file_path, "rb") as f:
+            engine = runtime.deserialize_cuda_engine(f.read())
+        context = engine.create_execution_context()
+
+        host_inputs = []
+        cuda_inputs = []
+        host_outputs = []
+        cuda_outputs = []
+        bindings = []
+
+        for binding in engine:
+            size = trt.volume(engine.get_binding_shape(binding)) * engine.max_batch_size
+            dtype = trt.nptype(engine.get_binding_dtype(binding))
+            # Allocate host and device buffers
+            host_mem = cuda.pagelocked_empty(size, dtype)
+            cuda_mem = cuda.mem_alloc(host_mem.nbytes)
+            # Append the device buffer to device bindings.
+            bindings.append(int(cuda_mem))
+            # Append to the appropriate list.
+            if engine.binding_is_input(binding):
+                self.input_w = engine.get_binding_shape(binding)[-2]
+                self.input_h = engine.get_binding_shape(binding)[-3]
+                host_inputs.append(host_mem)
+                cuda_inputs.append(cuda_mem)
+            else:
+                host_outputs.append(host_mem)
+                cuda_outputs.append(cuda_mem)
+
+        # Store
+        self.stream = stream
+        self.context = context
+        self.engine = engine
+        self.host_inputs = host_inputs
+        self.cuda_inputs = cuda_inputs
+        self.host_outputs = host_outputs
+        self.cuda_outputs = cuda_outputs
+        self.bindings = bindings
+        self.batch_size = engine.max_batch_size
+
+    def infer(self, image_raw):
+        threading.Thread.__init__(self)
+        # Make self the active context, pushing it on top of the context stack.
+        self.cfx.push()
+        # Restore
+        stream = self.stream
+        context = self.context
+        engine = self.engine
+        host_inputs = self.host_inputs
+        cuda_inputs = self.cuda_inputs
+        host_outputs = self.host_outputs
+        cuda_outputs = self.cuda_outputs
+        bindings = self.bindings
+        print('ori_shape: ', image_raw.shape)
+        # if image_raw is constant, image_raw.shape[1] != self.input_w
+        w_ori, h_ori = image_raw.shape[1], image_raw.shape[0]
+        # Do image preprocess
+        input_image = self.preprocess_image(image_raw)
+        # Copy input image to host buffer
+        np.copyto(host_inputs[0], input_image.ravel())
+        start = time.time()
+        # Transfer input data to the GPU.
+        cuda.memcpy_htod_async(cuda_inputs[0], host_inputs[0], stream)
+        # Run inference.
+        context.execute_async(bindings=bindings, stream_handle=stream.handle)
+        # Transfer predictions back from the GPU.
+        cuda.memcpy_dtoh_async(host_outputs[0], cuda_outputs[0], stream)
+        # Synchronize the stream
+        stream.synchronize()
+        end = time.time()
+        # Remove any context from the top of the context stack, deactivating it.
+        self.cfx.pop()
+        # Here we use the first row of output in that batch_size = 1
+        output = host_outputs[0]
+        # Do postprocess
+        output = output.reshape(self.input_h, self.input_w).astype('uint8')
+        print('output_shape: ', output.shape)
+        output = cv2.resize(output, (w_ori, h_ori))
+        return output, end - start
+
+    def destroy(self):
+        # Remove any context from the top of the context stack, deactivating it.
+        self.cfx.pop()
+
+    def preprocess_image(self, image_raw):
+        """
+        description: Read an image from image path, convert it to RGB,
+                    resize and pad it to target size.
+        param:
+            image_raw: numpy, raw image
+        return:
+            image:  the processed image
+        """
+        image = cv2.cvtColor(image_raw, cv2.COLOR_BGR2RGB)
+        resize = iaa.Resize({
+            'width': self.input_w,
+            'height': self.input_h
+        })
+        image = resize.augment_image(image)
+        print('resized', image.shape, image.dtype)
+        image = image.astype(np.float32)
+        return image
+
+    def get_raw_image(self, image_path_batch):
+        """
+        description: Read an image from image path
+        """
+        for img_path in image_path_batch:
+            return cv2.imread(img_path)
+    
+    def get_raw_image_zeros(self, image_path_batch=None):
+        """
+        description: Ready data for warmup
+        """
+        for _ in range(self.batch_size):
+            return np.zeros([self.input_h, self.input_w, 3], dtype=np.uint8)
+
+
+class inferThread(threading.Thread):
+    def __init__(self, hrnet_wrapper, image_path_batch):
+        threading.Thread.__init__(self)
+        self.hrnet_wrapper = hrnet_wrapper
+        self.image_path_batch = image_path_batch
+
+    def run(self):
+        batch_image_raw, use_time = self.hrnet_wrapper.infer(self.hrnet_wrapper.get_raw_image(self.image_path_batch))
+        for i, img_path in enumerate(self.image_path_batch):
+            parent, filename = os.path.split(img_path)
+            save_name = os.path.join('output', filename)
+            # Save image
+            cv2.imwrite(save_name, batch_image_raw*255)
+        print('input->{}, time->{:.2f}ms, saving into output/'.format(self.image_path_batch, use_time * 1000))
+
+
+class warmUpThread(threading.Thread):
+    def __init__(self, hrnet_wrapper):
+        threading.Thread.__init__(self)
+        self.hrnet_wrapper = hrnet_wrapper
+
+    def run(self):
+        batch_image_raw, use_time = self.hrnet_wrapper.infer(self.hrnet_wrapper.get_raw_image_zeros())
+        print('warm_up->{}, time->{:.2f}ms'.format(batch_image_raw[0].shape, use_time * 1000))
+
+
+
+if __name__ == "__main__":
+    # load custom engine
+    engine_file_path = "build/hrnet.engine"  # the generated engine file
+    
+    if len(sys.argv) > 1:
+        engine_file_path = sys.argv[1]
+
+    if os.path.exists('output/'):
+        shutil.rmtree('output/')
+    os.makedirs('output/')
+    # a hrnet instance
+    hrnet_wrapper = Hrnet_TRT(engine_file_path)
+    try:
+        print('batch size is', hrnet_wrapper.batch_size)  # batch size is set to 1!
+        
+        image_dir = "samples/"
+        image_path_batches = get_img_path_batches(hrnet_wrapper.batch_size, image_dir)
+
+        for i in range(10):
+            # create a new thread to do warm_up
+            thread1 = warmUpThread(hrnet_wrapper)
+            thread1.start()
+            thread1.join()
+        for batch in image_path_batches:
+            # create a new thread to do inference
+            thread1 = inferThread(hrnet_wrapper, batch)
+            thread1.start()
+            thread1.join()
+    finally:
+        # destroy the instance
+        hrnet_wrapper.destroy()

--- a/yolov5/yolov5_trt.py
+++ b/yolov5/yolov5_trt.py
@@ -254,11 +254,11 @@ class YoLov5TRT(object):
         param:
             origin_h:   height of original image
             origin_w:   width of original image
-            x:          A boxes tensor, each row is a box [center_x, center_y, w, h]
+            x:          A boxes numpy, each row is a box [center_x, center_y, w, h]
         return:
-            y:          A boxes tensor, each row is a box [x1, y1, x2, y2]
+            y:          A boxes numpy, each row is a box [x1, y1, x2, y2]
         """
-        y = torch.zeros_like(x) if isinstance(x, torch.Tensor) else np.zeros_like(x)
+        y = np.zeros_like(x)
         r_w = self.input_w / origin_w
         r_h = self.input_h / origin_h
         if r_h > r_w:
@@ -280,40 +280,94 @@ class YoLov5TRT(object):
         """
         description: postprocess the prediction
         param:
-            output:     A tensor likes [num_boxes,cx,cy,w,h,conf,cls_id, cx,cy,w,h,conf,cls_id, ...] 
+            output:     A numpy likes [num_boxes,cx,cy,w,h,conf,cls_id, cx,cy,w,h,conf,cls_id, ...] 
             origin_h:   height of original image
             origin_w:   width of original image
         return:
-            result_boxes: finally boxes, a boxes tensor, each row is a box [x1, y1, x2, y2]
-            result_scores: finally scores, a tensor, each element is the score correspoing to box
-            result_classid: finally classid, a tensor, each element is the classid correspoing to box
+            result_boxes: finally boxes, a boxes numpy, each row is a box [x1, y1, x2, y2]
+            result_scores: finally scores, a numpy, each element is the score correspoing to box
+            result_classid: finally classid, a numpy, each element is the classid correspoing to box
         """
         # Get the num of boxes detected
         num = int(output[0])
         # Reshape to a two dimentional ndarray
         pred = np.reshape(output[1:], (-1, 6))[:num, :]
-        # to a torch Tensor
-        pred = torch.Tensor(pred).cuda()
-        # Get the boxes
-        boxes = pred[:, :4]
-        # Get the scores
-        scores = pred[:, 4]
-        # Get the classid
-        classid = pred[:, 5]
-        # Choose those boxes that score > CONF_THRESH
-        si = scores > CONF_THRESH
-        boxes = boxes[si, :]
-        scores = scores[si]
-        classid = classid[si]
-        # Trandform bbox from [center_x, center_y, w, h] to [x1, y1, x2, y2]
-        boxes = self.xywh2xyxy(origin_h, origin_w, boxes)
         # Do nms
-        indices = torchvision.ops.nms(boxes, scores, iou_threshold=IOU_THRESHOLD).cpu()
-        result_boxes = boxes[indices, :].cpu()
-        result_scores = scores[indices].cpu()
-        result_classid = classid[indices].cpu()
+        boxes = self.non_max_suppression(pred, origin_h, origin_w, conf_thres=CONF_THRESH, nms_thres=IOU_THRESHOLD)
+        result_boxes = boxes[:, :4] if len(boxes) else np.array([])
+        result_scores = boxes[:, 4] if len(boxes) else np.array([])
+        result_classid = boxes[:, 5] if len(boxes) else np.array([])
         return result_boxes, result_scores, result_classid
 
+    def bbox_iou(self, box1, box2, x1y1x2y2=True):
+        """
+        description: compute the IoU of two bounding boxes
+        param:
+            box1: A box coordinate (can be (x1, y1, x2, y2) or (x, y, w, h))
+            box2: A box coordinate (can be (x1, y1, x2, y2) or (x, y, w, h))            
+            x1y1x2y2: select the coordinate format
+        return:
+            iou: computed iou
+        """
+        if not x1y1x2y2:
+            # Transform from center and width to exact coordinates
+            b1_x1, b1_x2 = box1[:, 0] - box1[:, 2] / 2, box1[:, 0] + box1[:, 2] / 2
+            b1_y1, b1_y2 = box1[:, 1] - box1[:, 3] / 2, box1[:, 1] + box1[:, 3] / 2
+            b2_x1, b2_x2 = box2[:, 0] - box2[:, 2] / 2, box2[:, 0] + box2[:, 2] / 2
+            b2_y1, b2_y2 = box2[:, 1] - box2[:, 3] / 2, box2[:, 1] + box2[:, 3] / 2
+        else:
+            # Get the coordinates of bounding boxes
+            b1_x1, b1_y1, b1_x2, b1_y2 = box1[:, 0], box1[:, 1], box1[:, 2], box1[:, 3]
+            b2_x1, b2_y1, b2_x2, b2_y2 = box2[:, 0], box2[:, 1], box2[:, 2], box2[:, 3]
+
+        # Get the coordinates of the intersection rectangle
+        inter_rect_x1 = np.maximum(b1_x1, b2_x1)
+        inter_rect_y1 = np.maximum(b1_y1, b2_y1)
+        inter_rect_x2 = np.minimum(b1_x2, b2_x2)
+        inter_rect_y2 = np.minimum(b1_y2, b2_y2)
+        # Intersection area
+        inter_area = np.clip(inter_rect_x2 - inter_rect_x1 + 1, 0, None) * \
+                     np.clip(inter_rect_y2 - inter_rect_y1 + 1, 0, None)
+        # Union Area
+        b1_area = (b1_x2 - b1_x1 + 1) * (b1_y2 - b1_y1 + 1)
+        b2_area = (b2_x2 - b2_x1 + 1) * (b2_y2 - b2_y1 + 1)
+
+        iou = inter_area / (b1_area + b2_area - inter_area + 1e-16)
+
+        return iou
+
+    def non_max_suppression(self, prediction, origin_h, origin_w, conf_thres=0.5, nms_thres=0.4):
+        """
+        description: Removes detections with lower object confidence score than 'conf_thres' and performs
+        Non-Maximum Suppression to further filter detections.
+        param:
+            prediction: detections, (x1, y1, x2, y2, conf, cls_id)
+            origin_h: original image height
+            origin_w: original image width
+            conf_thres: a confidence threshold to filter detections
+            nms_thres: a iou threshold to filter detections
+        return:
+            boxes: output after nms with the shape (x1, y1, x2, y2, conf, cls_id)
+        """
+        # Get the boxes that score > CONF_THRESH
+        boxes = prediction[prediction[:, 4] >= conf_thres]
+        # Trandform bbox from [center_x, center_y, w, h] to [x1, y1, x2, y2]
+        boxes[:, :4] = self.xywh2xyxy(origin_h, origin_w, boxes[:, :4])
+        # Object confidence
+        confs = boxes[:, 4]
+        # Sort by the confs
+        boxes = boxes[np.argsort(-confs)]
+        # Perform non-maximum suppression
+        keep_boxes = []
+        while boxes.shape[0]:
+            large_overlap = self.bbox_iou(np.expand_dims(boxes[0, :4], 0), boxes[:, :4]) > nms_thres
+            label_match = boxes[0, -1] == boxes[:, -1]
+            # Indices of boxes with lower confidence scores, large IOUs and matching labels
+            invalid = large_overlap & label_match
+            keep_boxes += [boxes[0]]
+            boxes = boxes[~invalid]
+        boxes = np.stack(keep_boxes, 0) if len(keep_boxes) else np.array([])
+        return boxes
 
 class inferThread(threading.Thread):
     def __init__(self, yolov5_wrapper, image_path_batch):
@@ -343,7 +397,7 @@ class warmUpThread(threading.Thread):
 
 
 if __name__ == "__main__":
-    # load custom plugins
+    # load custom plugin and engine
     PLUGIN_LIBRARY = "build/libmyplugins.so"
     engine_file_path = "build/yolov5s.engine"
 

--- a/yolov5/yolov5_trt.py
+++ b/yolov5/yolov5_trt.py
@@ -13,8 +13,6 @@ import numpy as np
 import pycuda.autoinit
 import pycuda.driver as cuda
 import tensorrt as trt
-import torch
-import torchvision
 
 CONF_THRESH = 0.5
 IOU_THRESHOLD = 0.4
@@ -368,6 +366,7 @@ class YoLov5TRT(object):
             boxes = boxes[~invalid]
         boxes = np.stack(keep_boxes, 0) if len(keep_boxes) else np.array([])
         return boxes
+
 
 class inferThread(threading.Thread):
     def __init__(self, yolov5_wrapper, image_path_batch):


### PR DESCRIPTION
- For decoupling the dependency of PyTorch, this code provides a pure numpy manner to write nms operation in yolov5_trt.py. I think it can offer simple and convenient TensorRT experience for yolov5.
- In detail, the following functions and codes were modified with the corresponding reason:
1.`pred = torch.Tensor(pred).cuda()` was deleted for saving GPU memory
2.`xywh2xyxy()` deleted the option of Tensor
3.`torchvision.ops.nms(boxes, scores, iou_threshold=IOU_THRESHOLD).cpu()` is replaced by a pure numpy code `self.non_max_suppression(pred, origin_h, origin_w, conf_thres=CONF_THRESH, nms_thres=IOU_THRESHOLD)`. This code contains the process of filtering detections with low confidence and common nms. 
4.`bbox_iou()` is added to compute the iou of two boxes for filtering the detection with high iou. The detections are sorted by confs with descending order.
5.The overall code structure is similar to yolov5_trt.py and the other codes there have not been modified. I have tested this code on my own dataset successfully, and if there are any bugs, contact me. I'm happy to fix them, THX.
In addition, the nms in yolov5_trt.py has no weighting ops, such as iou and confidence, which is not in accordance with git@github.com:ultralytics/yolov5.git. To get better detections, these ops can be included. Since the tensorRT engine output is (x, y, w, h, conf, cls_id), not (x, y, w, h, conf, prob1, prob2, ...), it is unavailable to implement these ops at this time.
Other question:
Is it a need to change the padding color of (128, 128, 128) to (114, 114, 114) in the `preprocess_image` function, since the training code in git@github.com:ultralytics/yolov5.git uses (114, 114, 114). BTW, for my case, this does not affect the result ^ - ^