### PR TITLE
Fix yolov5-v6 error

### DIFF
--- a/yolov5/gen_wts.py
+++ b/yolov5/gen_wts.py
@@ -28,6 +28,8 @@ pt_file, wts_file = parse_args()
 device = select_device('cpu')
 # Load model
 model = torch.load(pt_file, map_location=device)['model'].float()  # load to FP32
+delattr(model.model[-1], 'anchor_grid')  # model.model[-1] is detect layer
+model.model[-1].register_buffer("anchor_grid",torch.Tensor(model.yaml['anchors'])) #The parameters are saved in the OrderDict through the "register_buffer" method, and then saved to the weight.
 model.to(device).eval()
 
 with open(wts_file, 'w') as f:


### PR DESCRIPTION

**principle**
_V5_
[anchor_grid](https://github.com/ultralytics/yolov5/blob/f5b8f7d54c9fa69210da0177fec7ac2d9e4a627c/models/yolo.py#L37) saved in the OrderDict through the "register_buffer" method, so it can be saved in the weight.
_V6_
[anchor_grid](https://github.com/ultralytics/yolov5/blob/3d897986c794cad8e00b17718a1be9bcb61ef76d/models/yolo.py?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L47) is an ordinary Parameter object，so it cannot be saved in the weight.

**Features**
- No change in usage
- Supports all networks