### PR TITLE
Allow building with custom settings without modifying files

### DIFF
--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -25,6 +25,11 @@ Currently, we support yolov5 v1.0, v2.0, v3.0, v3.1, v4.0, v5.0 and v6.0.
 - BBox confidence thresh in yolov5.cpp
 - Batch size in yolov5.cpp
 
+An alternative to manually modifying source files, is define precompiler macros on the command line in order for cmake to pick them up.
+For example, instead of changing the number of classes (CLASS\_NUM from yololayer.h) to let's say 20, one can use `CXXFLAGS="-DEXT_CLASS_NUM=20" cmake ..`.
+This applies to (a bunch of) constants and macros from yololayer.h and yolov5.cpp. Multiple EXT\_\* macro definitions (-D) can be added to CXXFLAGS, separated by spaces.
+
+
 ## How to Run, yolov5s as example
 
 1. generate .wts from pytorch with .pt, or download .wts from model zoo

--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -52,18 +52,19 @@ cd build
 cp {ultralytics}/yolov5/yolov5s.wts {tensorrtx}/yolov5/build
 ```
 
-either:
-```
-// update CLASS_NUM in {tensorrtx}/yolov5/yololayer.h if your model is trained on custom dataset
-cmake ..
-```
+- either (regular way):
 
-or - with no file modifiction (for a model with a batch size of 4, and trained on custom dataset with 20 classes):
+    ```
+    // update CLASS_NUM in {tensorrtx}/yolov5/yololayer.h if your model is trained on custom dataset
+    cmake ..
+    ```
 
-```
-// instead of modifying constants and macros in files, define corresponding EXT_ macros on the command line (if necessary) like below
-CXXFLAGS="-DEXT_BATCH_SIZE=4 -DEXT_CLASS_NUM=20" cmake ..
-```
+- or - with no file modifiction (for a model with a batch size of 4, and trained on custom dataset with 20 classes):
+
+    ```
+    // instead of modifying constants and macros in files, define corresponding EXT_ macros on the command line (if necessary) like below
+    CXXFLAGS="-DEXT_BATCH_SIZE=4 -DEXT_CLASS_NUM=20" cmake ..
+    ```
 
 ```
 make

--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -93,7 +93,7 @@ python yolov5_trt.py
 
 2. unzip it in yolov5/build
 
-3. set the macro `USE_INT8` in yolov5.cpp (or pass in commandline `CXXFLAGS="-DUSE_INT8"`) and make
+3. set the macro `USE_INT8` in yolov5.cpp (or pass in commandline `CXXFLAGS="-DEXT_USE_INT8"`) and make
 
 4. serialize the model and test
 

--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -26,8 +26,8 @@ Currently, we support yolov5 v1.0, v2.0, v3.0, v3.1, v4.0, v5.0 and v6.0.
 - Batch size in yolov5.cpp
 
 An alternative to manually modifying source files, is define precompiler macros on the command line in order for cmake to pick them up.
-For example, instead of changing the number of classes (CLASS\_NUM from yololayer.h) to let's say 20, one can use `CXXFLAGS="-DEXT_CLASS_NUM=20" cmake ..`.
-This applies to (a bunch of) constants and macros from yololayer.h and yolov5.cpp. Multiple EXT\_\* macro definitions (-D) can be added to CXXFLAGS, separated by spaces.
+For example, instead of changing the number of classes (`CLASS_NUM` from yololayer.h) to let's say 20, one can use `CXXFLAGS="-DEXT_CLASS_NUM=20" cmake ..`.
+This applies to (a bunch of) constants and macros from yololayer.h and yolov5.cpp. Multiple EXT\_\* macro definitions (-D) can be added to `CXXFLAGS`, separated by spaces.
 
 
 ## How to Run, yolov5s as example
@@ -47,11 +47,25 @@ python gen_wts.py -w yolov5s.pt -o yolov5s.wts
 
 ```
 cd {tensorrtx}/yolov5/
-// update CLASS_NUM in yololayer.h if your model is trained on custom dataset
 mkdir build
 cd build
 cp {ultralytics}/yolov5/yolov5s.wts {tensorrtx}/yolov5/build
+```
+
+either:
+```
+// update CLASS_NUM in {tensorrtx}/yolov5/yololayer.h if your model is trained on custom dataset
 cmake ..
+```
+
+or - with no file modifiction (for a model with a batch size of 4, and trained on custom dataset with 20 classes):
+
+```
+// instead of modifying constants and macros in files, define corresponding EXT_ macros on the command line (if necessary) like below
+CXXFLAGS="-DEXT_BATCH_SIZE=4 -DEXT_CLASS_NUM=20" cmake ..
+```
+
+```
 make
 sudo ./yolov5 -s [.wts] [.engine] [n/s/m/l/x/n6/s6/m6/l6/x6 or c/c6 gd gw]  // serialize model to plan file
 sudo ./yolov5 -d [.engine] [image folder]  // deserialize and run inference, the images in [image folder] will be processed.
@@ -79,7 +93,7 @@ python yolov5_trt.py
 
 2. unzip it in yolov5/build
 
-3. set the macro `USE_INT8` in yolov5.cpp and make
+3. set the macro `USE_INT8` in yolov5.cpp (or pass in commandline `CXXFLAGS="-DUSE_INT8"`) and make
 
 4. serialize the model and test
 

--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -25,7 +25,7 @@ Currently, we support yolov5 v1.0, v2.0, v3.0, v3.1, v4.0, v5.0 and v6.0.
 - BBox confidence thresh in yolov5.cpp
 - Batch size in yolov5.cpp
 
-An alternative to manually modifying source files, is define precompiler macros on the command line in order for cmake to pick them up.
+An alternative to manually modifying source files, is define (C) preprocessor macros on the command line in order for cmake (and then the compiler) to pick them up.
 For example, instead of changing the number of classes (`CLASS_NUM` from yololayer.h) to let's say 20, one can use `CXXFLAGS="-DEXT_CLASS_NUM=20" cmake ..`.
 This applies to (a bunch of) constants and macros from yololayer.h and yolov5.cpp. Multiple EXT\_\* macro definitions (-D) can be added to `CXXFLAGS`, separated by spaces.
 

--- a/yolov5/yololayer.h
+++ b/yolov5/yololayer.h
@@ -8,20 +8,55 @@
 
 namespace Yolo
 {
+#if defined(EXT_CHECK_COUNT)
+    static constexpr int CHECK_COUNT = EXT_CHECK_COUNT;
+#else
     static constexpr int CHECK_COUNT = 3;
+#endif
+
+#if defined(EXT_IGNORE_THRESH)
+    static constexpr float IGNORE_THRESH = EXT_IGNORE_THRESH;
+#else
     static constexpr float IGNORE_THRESH = 0.1f;
+#endif
+
     struct YoloKernel
     {
         int width;
         int height;
         float anchors[CHECK_COUNT * 2];
     };
-    static constexpr int MAX_OUTPUT_BBOX_COUNT = 1000;
-    static constexpr int CLASS_NUM = 80;
-    static constexpr int INPUT_H = 640;  // yolov5's input height and width must be divisible by 32.
-    static constexpr int INPUT_W = 640;
 
+#if defined(EXT_MAX_OUTPUT_BBOX_COUNT)
+    static constexpr int MAX_OUTPUT_BBOX_COUNT = EXT_MAX_OUTPUT_BBOX_COUNT;
+#else
+    static constexpr int MAX_OUTPUT_BBOX_COUNT = 1000;
+#endif
+
+#if defined(EXT_CLASS_NUM)
+    static constexpr int CLASS_NUM = EXT_CLASS_NUM;
+#else
+    static constexpr int CLASS_NUM = 80;
+#endif
+
+#if defined(EXT_INPUT_H)
+    static constexpr int INPUT_H = EXT_INPUT_H;  // yolov5's input height and width must be divisible by 32.
+#else
+    static constexpr int INPUT_H = 640;  // yolov5's input height and width must be divisible by 32.
+#endif
+
+#if defined(EXT_INPUT_W)
+    static constexpr int INPUT_W = EXT_INPUT_W;
+#else
+    static constexpr int INPUT_W = 640;
+#endif
+
+#if defined(EXT_LOCATIONS)
+    static constexpr int LOCATIONS = EXT_LOCATIONS;
+#else
     static constexpr int LOCATIONS = 4;
+#endif
+
     struct alignas(float) Detection {
         //center_x center_y w h
         float bbox[LOCATIONS];

--- a/yolov5/yolov5.cpp
+++ b/yolov5/yolov5.cpp
@@ -8,10 +8,16 @@
 #include "calibrator.h"
 #include "preprocess.h"
 
-#define USE_FP16  // set USE_INT8 or USE_FP16 or USE_FP32
+#if defined(EXT_USE_INT8)
+#  define USE_INT8
+#elif defined(EXT_USE_FP32)
+#  define USE_FP32
+#else  // default (if not controlled from outside)
+#  define USE_FP16  // set USE_INT8 or USE_FP16 or USE_FP32
+#endif
 
 #if defined(EXT_DEVICE)
-#  define DEVICE EXT_DEVICE  // GPU id
+#  define DEVICE EXT_DEVICE
 #else
 #  define DEVICE 0  // GPU id
 #endif

--- a/yolov5/yolov5.cpp
+++ b/yolov5/yolov5.cpp
@@ -34,7 +34,7 @@
 #  define BATCH_SIZE 1
 #endif
 
-#define MAX_IMAGE_INPUT_SIZE_THRESH 3000 * 3000 // ensure it exceed the maximum size in the input images !
+#define MAX_IMAGE_INPUT_SIZE_THRESH (3000 * 3000) // ensure it exceed the maximum size in the input images !
 
 // stuff we know about the network and the input/output blobs
 static const int INPUT_H = Yolo::INPUT_H;

--- a/yolov5/yolov5.cpp
+++ b/yolov5/yolov5.cpp
@@ -9,10 +9,31 @@
 #include "preprocess.h"
 
 #define USE_FP16  // set USE_INT8 or USE_FP16 or USE_FP32
-#define DEVICE 0  // GPU id
-#define NMS_THRESH 0.4
-#define CONF_THRESH 0.5
-#define BATCH_SIZE 1
+
+#if defined(EXT_DEVICE)
+#  define DEVICE EXT_DEVICE  // GPU id
+#else
+#  define DEVICE 0  // GPU id
+#endif
+
+#if defined(EXT_NMS_THRESH)
+#  define NMS_THRESH EXT_NMS_THRESH
+#else
+#  define NMS_THRESH 0.4
+#endif
+
+#if defined(EXT_CONF_THRESH)
+#  define CONF_THRESH EXT_CONF_THRESH
+#else
+#  define CONF_THRESH 0.5
+#endif
+
+#if defined(EXT_BATCH_SIZE)
+#  define BATCH_SIZE EXT_BATCH_SIZE
+#else
+#  define BATCH_SIZE 1
+#endif
+
 #define MAX_IMAGE_INPUT_SIZE_THRESH 3000 * 3000 // ensure it exceed the maximum size in the input images !
 
 // stuff we know about the network and the input/output blobs


### PR DESCRIPTION
Right now *TRTx*'s *YOLOv5* engine build is not very automation friendly. That is because user is required to manually edit source files (depending on model, ...).

The items (from source files) that need adjustments are constant and preprocessor macros. This *PR* is proposing a new way of setting them by defining (other) preprocessor macros on the command line.
So, if item *X* needs to be set to value *Y*, the way of doing things is defining *EXT\_X* to *Y*, and pass it to *cmake*. 
For example if converting a custom dataset trained model with 20 classes, and opting for a batch size of 4, the conversion process would simpy be:

    CXXFLAGS="-DEXT_BATCH_SIZE=4 -DEXT_CLASS_NUM=20" cmake ..

and *CMake* will add these definitions in its flag files.

This is very good for automation - launching the build process from scripts.

Needless to say that current behavior is still the default.


As a final note, I only needed this for 4 items, but I handled 11.
