### PR TITLE
Fix wrong use of copyMakeBorder

### DIFF
--- a/yolov5/yolov5_trt.py
+++ b/yolov5/yolov5_trt.py
@@ -233,7 +233,7 @@ class YoLov5TRT(object):
         image = cv2.resize(image, (tw, th))
         # Pad the short side with (128,128,128)
         image = cv2.copyMakeBorder(
-            image, ty1, ty2, tx1, tx2, cv2.BORDER_CONSTANT, (128, 128, 128)
+            image, ty1, ty2, tx1, tx2, cv2.BORDER_CONSTANT, None, (128, 128, 128)
         )
         image = image.astype(np.float32)
         # Normalize to [0,1]


### PR DESCRIPTION
The `dst` parameter of `cv2.copyMakeBorder` should use `None`, otherwise the padded value is **0** instead of **128**.
