### PR TITLE
Modifications in rcnn.cpp for more applicable outputs of instance segmentation. 

### DIFF
--- a/rcnn/README.md
+++ b/rcnn/README.md
@@ -1,6 +1,6 @@
 # Rcnn
 
-The Pytorch implementation is [facebookresearch/detectron2](https://github.com/facebookresearch/detectron2).
+The Pytorch implementation is [facebookresearch/detectron2](https://github.com/facebookresearch/detectron2). Now, outputting instance segmentation results on the original image size is available, which is more convenient for engineering applications.
 
 ## Models
 
@@ -114,9 +114,10 @@ sudo ./rcnn -d faster.engine ../samples
   error: __host__ or __device__ annotation on lambda requires --extended-lambda nvcc flag
   ```
 
-- the image preprocess was moved into tensorrt, see DataPreprocess in rcnn.cpp, so the input data is {H, W, C}
+- the image preprocess of sizing and padding was moved out from tensorrt, see DataPreprocess in rcnn.cpp, so the input data is {H, W, C}
+- now, left-right and top-bottom padding preprocessings are optionally available in preprocessImg of common.hpp, and you can set arbitrary sizes of INPUT_H_ and INPUT_W_
 
-- the predicted boxes is corresponding to new image size, so the final boxes need to multiply with the ratio, see calculateRatio in rcnn.cpp
+- the predicted boxes is corresponding to new image size containing padding, so the final boxes need to subtract padding size and multiply with the ratio, see preprocessImg in common.hpp and calculateSize in rcnn.cpp
 
 - tensorrt use fixed input size, if the size of your data is different from the engine, you need to adjust your data and the result.
 

--- a/rcnn/calibrator.hpp
+++ b/rcnn/calibrator.hpp
@@ -76,7 +76,12 @@ bool Int8EntropyCalibrator2::getBatch(void* bindings[], const char* names[], int
     for (int i = img_idx_; i < img_idx_ + batchsize_; i++) {
         std::cout << img_files_[i] << "  " << i << std::endl;
         cv::Mat temp = cv::imread(img_dir_ + img_files_[i]);
-        temp = preprocessImg(temp, input_w_, input_h_);
+        int X_LEFT_PAD = 0;
+        int X_RIGHT_PAD = 0; 
+        int Y_TOP_PAD = 0;
+        int Y_BOTTOM_PAD = 0;
+        temp = preprocessImg(temp, input_w_, input_h_, X_LEFT_PAD, X_RIGHT_PAD, Y_TOP_PAD, Y_BOTTOM_PAD);
+
         if (temp.empty()) {
             std::cerr << "Fatal error: image cannot open!" << std::endl;
             return false;

--- a/rcnn/common.hpp
+++ b/rcnn/common.hpp
@@ -81,6 +81,8 @@ static inline cv::Mat preprocessImg(cv::Mat& img, int input_w, int input_h) {
     float x, y;
     float r_w = input_w / (img.cols*1.0);
     float r_h = input_h / (img.rows*1.0);
+
+    // this code can also support left-right and top-bottom padding if you need
     if (r_h > r_w) {
         w = input_w;
         h = r_w * img.rows;

--- a/rcnn/common.hpp
+++ b/rcnn/common.hpp
@@ -76,7 +76,7 @@ static inline int read_files_in_dir(const char *p_dir_name, std::vector<std::str
     return 0;
 }
 
-static inline cv::Mat preprocessImg(cv::Mat& img, int input_w, int input_h) {
+static inline cv::Mat preprocessImg(cv::Mat& img, int input_w, int input_h, int& X_LEFT_PAD, int& X_RIGHT_PAD, int& Y_TOP_PAD, int& Y_BOTTOM_PAD) {
     int w, h;
     float x, y;
     float r_w = input_w / (img.cols*1.0);
@@ -96,10 +96,10 @@ static inline cv::Mat preprocessImg(cv::Mat& img, int input_w, int input_h) {
     }
 
     // support both odd and even cases
-    int X_LEFT_PAD = (int)(round(x - 0.1));
-    int X_RIGHT_PAD = (int)(round(x + 0.1));
-    int Y_TOP_PAD = (int)(round(y - 0.1));
-    int Y_BOTTOM_PAD = (int)(round(y + 0.1));
+    X_LEFT_PAD = (int)(round(x - 0.1));
+    X_RIGHT_PAD = (int)(round(x + 0.1));
+    Y_TOP_PAD = (int)(round(y - 0.1));
+    Y_BOTTOM_PAD = (int)(round(y + 0.1));
 
     cv::Mat re(h, w, CV_8UC3);
     cv::resize(img, re, re.size(), 0, 0, cv::INTER_LINEAR);

--- a/rcnn/common.hpp
+++ b/rcnn/common.hpp
@@ -77,23 +77,32 @@ static inline int read_files_in_dir(const char *p_dir_name, std::vector<std::str
 }
 
 static inline cv::Mat preprocessImg(cv::Mat& img, int input_w, int input_h) {
-    int w, h, x, y;
+    int w, h;
+    float x, y;
     float r_w = input_w / (img.cols*1.0);
     float r_h = input_h / (img.rows*1.0);
     if (r_h > r_w) {
         w = input_w;
         h = r_w * img.rows;
-        x = 0;
+        x = 0.0;
         y = (input_h - h) / 2;
     } else {
         w = r_h * img.cols;
         h = input_h;
         x = (input_w - w) / 2;
-        y = 0;
+        y = 0.0;
     }
+
+    // support both odd and even cases
+    int X_LEFT_PAD = (int)(round(x - 0.1));
+    int X_RIGHT_PAD = (int)(round(x + 0.1));
+    int Y_TOP_PAD = (int)(round(y - 0.1));
+    int Y_BOTTOM_PAD = (int)(round(y + 0.1));
+
     cv::Mat re(h, w, CV_8UC3);
     cv::resize(img, re, re.size(), 0, 0, cv::INTER_LINEAR);
     cv::Mat out(input_h, input_w, CV_8UC3, cv::Scalar(128, 128, 128));
-    re.copyTo(out(cv::Rect(x, y, re.cols, re.rows)));
+    re.copyTo(out(cv::Rect(X_LEFT_PAD, Y_TOP_PAD, re.cols, re.rows)));
+
     return out;
 }

--- a/rcnn/common.hpp
+++ b/rcnn/common.hpp
@@ -85,11 +85,11 @@ static inline cv::Mat preprocessImg(cv::Mat& img, int input_w, int input_h) {
         w = input_w;
         h = r_w * img.rows;
         x = 0.0;
-        y = (input_h - h) / 2;
+        y = (input_h - h) / 2.f;
     } else {
         w = r_h * img.cols;
         h = input_h;
-        x = (input_w - w) / 2;
+        x = (input_w - w) / 2.f;
         y = 0.0;
     }
 

--- a/rcnn/rcnn.cpp
+++ b/rcnn/rcnn.cpp
@@ -375,7 +375,7 @@ bool parse_args(int argc, char** argv, std::string& wtsFile, std::string& engine
 }
 
 int main(int argc, char** argv) {
-    
+
     // calculate size
     calculateSize();
 
@@ -477,7 +477,7 @@ int main(int argc, char** argv) {
             cv::Mat img = cv::imread(imgDir + "/" + fileList[f - fcount + 1 + b]);
             h_ori = img.rows;
             w_ori = img.cols;
-            img = preprocessImg(img, INPUT_W, INPUT_H);
+            img = preprocessImg(img, INPUT_W, INPUT_H, X_LEFT_PAD, X_RIGHT_PAD, Y_TOP_PAD, Y_BOTTOM_PAD);
 
             if (img.empty()) continue;
             for (int i = 0; i < INPUT_H * INPUT_W * 3; i++)
@@ -511,7 +511,7 @@ int main(int argc, char** argv) {
                     cv::putText(img, std::to_string(label), cv::Point(r.x, r.y - 1), cv::FONT_HERSHEY_PLAIN, 1.2,
                     cv::Scalar(0xFF, 0xFF, 0xFF), 2);
 
-                    
+
                     if (MASK_ON) {
                         cv::Mat maskPart = cv::Mat::zeros(cv::Size(POOLER_RESOLUTION, POOLER_RESOLUTION), CV_32FC1);
                         memcpy(maskPart.data,

--- a/rcnn/rcnn.cpp
+++ b/rcnn/rcnn.cpp
@@ -17,11 +17,11 @@ static const std::vector<float> PIXEL_MEAN = { 103.53, 116.28, 123.675 };
 static const std::vector<float> PIXEL_STD = {1.0, 1.0, 1.0};
 static constexpr float MIN_SIZE = 800.0;
 static constexpr float MAX_SIZE = 1333.0;
-static constexpr int NUM_CLASSES = 1;
+static constexpr int NUM_CLASSES = 80;
 static int INPUT_H;  // size of model input
 static int INPUT_W;
-static constexpr int INPUT_H_ = 1024;  // size of original image, you can change it to arbitrary size
-static constexpr int INPUT_W_ = 2048;
+static constexpr int INPUT_H_ = 480;  // size of original image, you can change it to arbitrary size
+static constexpr int INPUT_W_ = 640;
 static int X_LEFT_PAD;  // pad in preprocessImg
 static int X_RIGHT_PAD;
 static int Y_TOP_PAD;

--- a/rcnn/rcnn.cpp
+++ b/rcnn/rcnn.cpp
@@ -78,14 +78,15 @@ cv::Mat preprocessImg_(cv::Mat& img, int input_w, int input_h) {
         w = input_w;
         h = r_w * img.rows;
         x = 0.0;
-        y = (input_h - h) / 2;
+        y = (input_h - h) / 2.f;
     } else {
         w = r_h * img.cols;
         h = input_h;
-        x = (input_w - w) / 2;
+        x = (input_w - w) / 2.f;
         y = 0.0;
     }
-
+    std::cout << x << std::endl;
+    std::cout << y << std::endl;
     // support both odd and even cases
     X_LEFT_PAD = (int)(round(x - 0.1));
     X_RIGHT_PAD = (int)(round(x + 0.1));


### PR DESCRIPTION
When using the rcnn.cpp to do inference, i find that the outputs of instance segmentation are on a padded input image rather than an original image. This will be inconvenient for me or other users to directly apply the results in specific cases. Therefore, I modified this cpp which supports the following functions now:
-  this cpp is consistent with the detectron2 training code where padding is not used. Only needs to set the vars of INPUT_H_ and INPUT_W_ to be same as the original training data. (e.g., if use cityscapes, INPUT_H_=1024, INPUT_W_=2048). The ResizeShortestEdge op will be applied automatically.
- additionally, this code also supports when the input image size is not same as the training data. For this, padding is applied. Of course, the instance segmentation results will be corrected according to the padding and resizing ops.
-  main codes are not modified.
This code has been tested on cityscapes, validating the effectiveness on different input image sizes. Any questions are appreciated ^-^.