### PR TITLE
修改yolov5的图片尺寸算法warpaffine_kernel()

### DIFF
--- a/yolov5/preprocess.cu
+++ b/yolov5/preprocess.cu
@@ -29,9 +29,9 @@ __global__ void warpaffine_kernel(
         c2 = const_value_st;
     } else {
         int y_low = floorf(src_y);
-		int x_low = floorf(src_x);
-		int y_high = ceil(src_y);
-		int x_high = ceil(src_x);
+	int x_low = floorf(src_x);
+	int y_high = ceil(src_y);
+	int x_high = ceil(src_x);
 
         uint8_t const_value[] = {const_value_st, const_value_st, const_value_st};
         float ly = src_y - y_low;

--- a/yolov5/preprocess.cu
+++ b/yolov5/preprocess.cu
@@ -18,8 +18,8 @@ __global__ void warpaffine_kernel(
 
     int dx = position % dst_width;
     int dy = position / dst_width;
-    float src_x = m_x1 * dx + m_y1 * dy + m_z1 + 0.5f;
-    float src_y = m_x2 * dx + m_y2 * dy + m_z2 + 0.5f;
+    float src_x = m_x1 * dx + m_y1 * dy + m_z1;
+    float src_y = m_x2 * dx + m_y2 * dy + m_z2;
     float c0, c1, c2;
 
     if (src_x <= -1 || src_x >= src_width || src_y <= -1 || src_y >= src_height) {
@@ -29,9 +29,9 @@ __global__ void warpaffine_kernel(
         c2 = const_value_st;
     } else {
         int y_low = floorf(src_y);
-        int x_low = floorf(src_x);
-        int y_high = y_low + 1;
-        int x_high = x_low + 1;
+		int x_low = floorf(src_x);
+		int y_high = ceil(src_y);
+		int x_high = ceil(src_x);
 
         uint8_t const_value[] = {const_value_st, const_value_st, const_value_st};
         float ly = src_y - y_low;


### PR DESCRIPTION
根据老师您原来的算法如果原始图片的src_x的小数部分大于0.5的情况, 例如src_x=10.6, 那么x_low=11, x_high=12 ; 取的都是右侧的值. 
我这里改成了floorf和ceil函数, 可以取到上下左右四个像素.
我最近才接触opencv, 也许理解的不到位, 老师有空看一下吧, 微信也给您留言了, 估计您没看到.