### PR TITLE
Implement setting input shape/class num in cmake

### DIFF
--- a/yolov5/CMakeLists.txt
+++ b/yolov5/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 2.6)
 
 project(yolov5)
 
+set(YOLO_CLASS_NUM 60 CACHE STRING "(int) Number of classes of objects")
+set(YOLO_INPUT_H 640 CACHE STRING "(int) Input image height. Must be divisible by 32")
+set(YOLO_INPUT_W 640 CACHE STRING "(int) Input image width. Must be divisible by 32")
+
+add_compile_definitions(
+  YOLO_CLASS_NUM=${YOLO_CLASS_NUM} YOLO_INPUT_H=${YOLO_INPUT_H}
+  YOLO_INPUT_W=${YOLO_INPUT_W})
+
 add_definitions(-std=c++11)
 add_definitions(-DAPI_EXPORTS)
 option(CUDA_USE_STATIC_CUDA_RUNTIME OFF)

--- a/yolov5/README.md
+++ b/yolov5/README.md
@@ -18,7 +18,9 @@ Currently, we support yolov5 v1.0, v2.0, v3.0, v3.1, v4.0, v5.0 and v6.0.
 
 - Choose the model n/s/m/l/x/n6/s6/m6/l6/x6 from command line arguments.
 - Input shape defined in yololayer.h
+  - CMake configuration: Set `-DYOLO_INPUT_W=your-input-width` and / or `-DYOLO_INPUT_H=your-input-height`
 - Number of classes defined in yololayer.h, **DO NOT FORGET TO ADAPT THIS, If using your own model**
+  - CMake configuration: Set `-DYOLO_CLASS_NUM=your-number-of-classes`
 - INT8/FP16/FP32 can be selected by the macro in yolov5.cpp, **INT8 need more steps, pls follow `How to Run` first and then go the `INT8 Quantization` below**
 - GPU id can be selected by the macro in yolov5.cpp
 - NMS thresh in yolov5.cpp

--- a/yolov5/yololayer.h
+++ b/yolov5/yololayer.h
@@ -6,6 +6,18 @@
 #include <NvInfer.h>
 #include "macros.h"
 
+#ifndef YOLO_CLASS_NUM
+#define YOLO_CLASS_NUM 60
+#endif
+
+#ifndef YOLO_INPUT_H
+#define YOLO_INPUT_H 640
+#endif
+
+#ifndef YOLO_INPUT_W
+#define YOLO_INPUT_W 640
+#endif
+
 namespace Yolo
 {
     static constexpr int CHECK_COUNT = 3;
@@ -17,9 +29,9 @@ namespace Yolo
         float anchors[CHECK_COUNT * 2];
     };
     static constexpr int MAX_OUTPUT_BBOX_COUNT = 1000;
-    static constexpr int CLASS_NUM = 80;
-    static constexpr int INPUT_H = 640;  // yolov5's input height and width must be divisible by 32.
-    static constexpr int INPUT_W = 640;
+    static constexpr int CLASS_NUM = YOLO_CLASS_NUM;
+    static constexpr int INPUT_H = YOLO_INPUT_H;  // yolov5's input height and width must be divisible by 32.
+    static constexpr int INPUT_W = YOLO_INPUT_W;
 
     static constexpr int LOCATIONS = 4;
     struct alignas(float) Detection {


### PR DESCRIPTION
This PR addresses the issue that oft-changed configuration variables `INPUT_W`/`INPUT_H` and `CLASS_NUM` are embedded in the source code. We introduce relevant CMake variables such that users can pass variables, for example, `-DYOLO_CLASS_NUM=10` or `-DYOLO_INPUT_W=416` to cmake, and let cmake configure the build automatically, without touching the source files.