### PR TITLE
Attach the decode kernel to the same CUDA stream

### DIFF
--- a/retinaface/decode.cu
+++ b/retinaface/decode.cu
@@ -176,14 +176,14 @@ namespace nvinfer1
         totalCount += decodeplugin::INPUT_H / 16 * decodeplugin::INPUT_W / 16 * 2 * sizeof(decodeplugin::Detection) / sizeof(float);
         totalCount += decodeplugin::INPUT_H / 32 * decodeplugin::INPUT_W / 32 * 2 * sizeof(decodeplugin::Detection) / sizeof(float);
         for(int idx = 0 ; idx < batchSize; ++idx) {
-            cudaMemset(output + idx * totalCount, 0, sizeof(float));
+            cudaMemsetAsync(output + idx * totalCount, 0, sizeof(float), stream);
         }
 
         for (unsigned int i = 0; i < 3; ++i)
         {
             num_elem = batchSize * decodeplugin::INPUT_H / base_step * decodeplugin::INPUT_W / base_step;
             thread_count = (num_elem < thread_count_) ? num_elem : thread_count_;
-            CalDetection<<< (num_elem + thread_count - 1) / thread_count, thread_count>>>
+            CalDetection<<< (num_elem + thread_count - 1) / thread_count, thread_count, 0, stream>>>
                 (inputs[i], output, num_elem, base_step, base_anchor, totalCount);
             base_step *= 2;
             base_anchor *= 4;


### PR DESCRIPTION
**_Support for loading RetinaFace engine file in DeepStream_**

**Problem:** 
- "during execution, I found that my program could hardly make any inferences. I looked at the output and found that the model’s confidence in almost all Anchor predictions is 0.5. After checking the entire process of the entire pipeline, I found that the output of the model before the last Softmax layer is almost all 0, which means that my model parameters are hardly loaded"
- the decode kernel is not attached to the same CUDA stream and lead to this issue.
- [full problem description and discussion are here](https://forums.developer.nvidia.com/t/is-there-anything-that-needs-extra-attention-when-using-my-own-engine-file/141134)

[**Fix extracted from here**](https://forums.developer.nvidia.com/t/is-there-anything-that-needs-extra-attention-when-using-my-own-engine-file/141134/17)

I also had this problem. After applying the fix, I has verified it work well in DeepStream 6.1.1
