### PR TITLE
yolov5: update `load strides from model file`

### DIFF
--- a/yolov5/common.hpp
+++ b/yolov5/common.hpp
@@ -294,8 +294,9 @@ IPluginV2Layer* addYoLoLayer(INetworkDefinition *network, std::map<std::string, 
     plugin_fields[0].length = 4;
     plugin_fields[0].name = "netinfo";
     plugin_fields[0].type = PluginFieldType::kFLOAT32;
+
     //load strides from Detect layer
-    assert(weightMap.find(lname + ".strides") != weightMap.end() && "Not found `strides`!!!, please check gen_wts.py!!!");
+    assert(weightMap.find(lname + ".strides") != weightMap.end() && "Not found `strides`, please check gen_wts.py!!!");
     Weights strides = weightMap[lname + ".strides"];
     auto *p = (const float*)(strides.values);
     std::vector<int> scales(p, p + strides.count);
@@ -304,7 +305,7 @@ IPluginV2Layer* addYoLoLayer(INetworkDefinition *network, std::map<std::string, 
     for (size_t i = 0; i < anchors.size(); i++) {
         Yolo::YoloKernel kernel;
         kernel.width = Yolo::INPUT_W / scales[i];
-        kernel.height = Yolo::INPUT_H / scale[i];
+        kernel.height = Yolo::INPUT_H / scales[i];
         memcpy(kernel.anchors, &anchors[i][0], anchors[i].size() * sizeof(float));
         kernels.push_back(kernel);
     }

--- a/yolov5/common.hpp
+++ b/yolov5/common.hpp
@@ -294,15 +294,19 @@ IPluginV2Layer* addYoLoLayer(INetworkDefinition *network, std::map<std::string, 
     plugin_fields[0].length = 4;
     plugin_fields[0].name = "netinfo";
     plugin_fields[0].type = PluginFieldType::kFLOAT32;
-    int scale = 8;
+    //load strides from Detect layer
+    assert(weightMap.find(lname + ".strides") != weightMap.end() && "Not found `strides`!!!, please check gen_wts.py!!!");
+    Weights strides = weightMap[lname + ".strides"];
+    auto *p = (const float*)(strides.values);
+    std::vector<int> scales(p, p + strides.count);
+
     std::vector<Yolo::YoloKernel> kernels;
     for (size_t i = 0; i < anchors.size(); i++) {
         Yolo::YoloKernel kernel;
-        kernel.width = Yolo::INPUT_W / scale;
-        kernel.height = Yolo::INPUT_H / scale;
+        kernel.width = Yolo::INPUT_W / scales[i];
+        kernel.height = Yolo::INPUT_H / scale[i];
         memcpy(kernel.anchors, &anchors[i][0], anchors[i].size() * sizeof(float));
         kernels.push_back(kernel);
-        scale *= 2;
     }
     plugin_fields[1].data = &kernels[0];
     plugin_fields[1].length = kernels.size();

--- a/yolov5/gen_wts.py
+++ b/yolov5/gen_wts.py
@@ -43,6 +43,7 @@ if m_type == "detect":
     delattr(model.model[-1], 'anchor_grid')  # model.model[-1] is detect layer
     # The parameters are saved in the OrderDict through the "register_buffer" method, and then saved to the weight.
     model.model[-1].register_buffer("anchor_grid", anchor_grid)
+    model.model[-1].register_buffer("strides", model.model[-1].stride)
 
 model.to(device).eval()
 


### PR DESCRIPTION
Setting `scale` as a `const` is unreasonable. 
https://github.com/wang-xinyu/tensorrtx/blob/dec5d5e1aa108d9500562816436d1ce6b039377c/yolov5/common.hpp#L297
**Update List:**
1. update `gen_wts.py` 
```python
model.model[-1].register_buffer("strides", model.model[-1].stride)
```
2. update `common.h`
```cpp
//load strides from Detect layer
assert(weightMap.find(lname + ".strides") != weightMap.end() && "Not found `strides`!!!, please check gen_wts.py!!!");
Weights strides = weightMap[lname + ".strides"];
auto *p = (const float*)(strides.values);
std::vector<int> scales(p, p + strides.count);
```