### PR TITLE
TensorRT 8.x supported

### DIFF
--- a/unet/README.md
+++ b/unet/README.md
@@ -11,9 +11,8 @@ Pytorch model from [Pytorch-UNet](https://github.com/milesial/Pytorch-UNet).
 
 ## Requirements
 
-Please use TensorRT 7.x.
-
-There is a bug with TensorRT 8.x, we are working on it.
+Now TensorRT 8.x is supported and you can use it.
+The key cause of the previous bug is the pooling layer Stride setting problem.
 
 ## Build and Run
 

--- a/unet/README.md
+++ b/unet/README.md
@@ -8,6 +8,8 @@ Pytorch model from [Pytorch-UNet](https://github.com/milesial/Pytorch-UNet).
 <a href="https://github.com/East-Face"><img src="https://avatars.githubusercontent.com/u/35283869?v=4s=48" width="40px;" alt=""/></a>
 <a href="https://github.com/irvingzhang0512"><img src="https://avatars.githubusercontent.com/u/22089207?s=48&v=4" width="40px;" alt=""/></a>
 <a href="https://github.com/wang-xinyu"><img src="https://avatars.githubusercontent.com/u/15235574?s=48&v=4" width="40px;" alt=""/></a>
+<a href="https://github.com/nengwp"><img src="https://avatars.githubusercontent.com/u/44516353?s=96&v=4" width="40px;" alt=""/></a>
+
 
 ## Requirements
 

--- a/unet/unet.cpp
+++ b/unet/unet.cpp
@@ -41,6 +41,7 @@ ILayer* doubleConv(INetworkDefinition* network, std::map<std::string, Weights>& 
 
 ILayer* down(INetworkDefinition* network, std::map<std::string, Weights>& weightMap, ITensor& input, int outch, int p, std::string lname) {
   IPoolingLayer* pool1 = network->addPoolingNd(input, PoolingType::kMAX, DimsHW{ 2, 2 });
+  pool1->setStrideNd(DimsHW{ 2, 2 });
   assert(pool1);
   ILayer* dcov1 = doubleConv(network, weightMap, *pool1->getOutput(0), outch, 3, lname + ".maxpool_conv.1", outch);
   assert(dcov1);


### PR DESCRIPTION
Now TensorRT 8.x is supported and you can use it.
The key cause of the previous bug is the pooling layer Stride setting problem.