### PR TITLE
Adapt ufld model to tensorrt8

### DIFF
--- a/ufld/CMakeLists.txt
+++ b/ufld/CMakeLists.txt
@@ -8,13 +8,13 @@ option(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Debug)
 
-find_package(CUDA REQUIRED)
+# cuda directory
+include_directories(/usr/local/cuda/include/)
+link_directories(/usr/local/cuda/lib64/)
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
-# cuda_runtime_api
-include_directories(/usr/local/cuda-10.2/targets/aarch64-linux/include)
-link_directories(/usr/local/cuda-10.2/targets/aarch64-linux/lib)
+# tensorrt
+#include_directories(/workspace/TensorRT-7.2.3.4/include/)
+#link_directories(/workspace/TensorRT-7.2.3.4/lib/)
 
 
 find_package(OpenCV)

--- a/ufld/CMakeLists.txt
+++ b/ufld/CMakeLists.txt
@@ -12,6 +12,11 @@ find_package(CUDA REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
+# cuda_runtime_api
+include_directories(/usr/local/cuda-10.2/targets/aarch64-linux/include)
+link_directories(/usr/local/cuda-10.2/targets/aarch64-linux/lib)
+
+
 find_package(OpenCV)
 include_directories(${OpenCV_INCLUDE_DIRS})
 

--- a/ufld/gen_wts.py
+++ b/ufld/gen_wts.py
@@ -4,7 +4,7 @@ import struct
 from model.model import parsingNet
 
 # Initialize
-model = parsingNet(pretrained = False, backbone='18', cls_dim = (101, 56, 4), use_aux=False).cuda()
+model = parsingNet(pretrained = False, backbone='18', cls_dim = (101, 56, 4), use_aux=False)
 device = 'cpu'
 # Load model
 state_dict = torch.load('tusimple_18.pth', map_location='cpu')['model']

--- a/ufld/logging.h
+++ b/ufld/logging.h
@@ -220,7 +220,7 @@ public:
     //! Note samples should not be calling this function directly; it will eventually go away once we eliminate the
     //! inheritance from nvinfer1::ILogger
     //!
-    void log(Severity severity, const char* msg) override
+    void log(Severity severity, const char* msg) noexcept override
     {
         LogStreamConsumer(mReportableSeverity, severity) << "[TRT] " << std::string(msg) << std::endl;
     }

--- a/ufld/logging.h
+++ b/ufld/logging.h
@@ -9,6 +9,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include "macros.h"
 
 using Severity = nvinfer1::ILogger::Severity;
 
@@ -220,7 +221,7 @@ public:
     //! Note samples should not be calling this function directly; it will eventually go away once we eliminate the
     //! inheritance from nvinfer1::ILogger
     //!
-    void log(Severity severity, const char* msg) noexcept override
+    void log(Severity severity, const char* msg) TRT_NOEXCEPT override 
     {
         LogStreamConsumer(mReportableSeverity, severity) << "[TRT] " << std::string(msg) << std::endl;
     }

--- a/ufld/macros.h
+++ b/ufld/macros.h
@@ -1,0 +1,27 @@
+#ifndef __MACROS_H
+#define __MACROS_H
+
+#ifdef API_EXPORTS
+#if defined(_MSC_VER)
+#define API __declspec(dllexport)
+#else
+#define API __attribute__((visibility("default")))
+#endif
+#else
+
+#if defined(_MSC_VER)
+#define API __declspec(dllimport)
+#else
+#define API
+#endif
+#endif  // API_EXPORTS
+
+#if NV_TENSORRT_MAJOR >= 8
+#define TRT_NOEXCEPT noexcept
+#define TRT_CONST_ENQUEUE const
+#else
+#define TRT_NOEXCEPT
+#define TRT_CONST_ENQUEUE
+#endif
+
+#endif  // __MACROS_H


### PR DESCRIPTION

I changed some source code ，and adapt ufld model to tensorrt8
Now，it works fine in my machine.

I use command `./lane_det -s` it genereted lane.engine successfully, and I also use command `./lane_det -d ./files/` to test
, it works fine too!
## env

 **jetson nano**
Jetpack: 4.6.1
- Cuda: 10.2.300
- cuDNN: 8.2.1.32
- TensorRT: 8.2.1.8
- OpenCV: 4.5.5
- Python: 3.7.12