### PR TITLE
fix segement fault using shared_ptr

### DIFF
--- a/yolov5/src/postprocess.h
+++ b/yolov5/src/postprocess.h
@@ -11,6 +11,6 @@ void batch_nms(std::vector<std::vector<Detection>>& batch_res, float *output, in
 
 void draw_bbox(std::vector<cv::Mat>& img_batch, std::vector<std::vector<Detection>>& res_batch);
 
-std::vector<cv::Mat> process_mask(const float* proto, int proto_size, std::vector<Detection>& dets);
+std::vector<std::shared_ptr<cv::Mat>> process_mask(const float* proto, int proto_size, std::vector<Detection>& dets);
 
-void draw_mask_bbox(cv::Mat& img, std::vector<Detection>& dets, std::vector<cv::Mat>& masks, std::unordered_map<int, std::string>& labels_map);
+void draw_mask_bbox(cv::Mat& img, std::vector<Detection>& dets, std::vector<std::shared_ptr<cv::Mat>>& masks, std::unordered_map<int, std::string>& labels_map);


### PR DESCRIPTION

Use shared_ptr to avoid memory issues, when masks.size()==0

```
Thread 1 "yolov5_seg" received signal SIGSEGV, Segmentation fault.
0x00007fffe7ea547e in __GI___libc_free (mem=0x1c7f8f46d9cd4cbf) at ./malloc/malloc.c:3368
3368 ./malloc/malloc.c: No such file or directory.
(gdb) bt
#0  0x00007fffe7ea547e in __GI___libc_free (mem=0x1c7f8f46d9cd4cbf) at ./malloc/malloc.c:3368
#1  0x00007fffe872bec9 in ?? () from /lib/x86_64-linux-gnu/libopencv_core.so.4.5d
#2  0x00007fffe872f062 in cv::Mat::release() () from /lib/x86_64-linux-gnu/libopencv_core.so.4.5d
#3  0x00007fffe872f081 in cv::Mat::~Mat() () from /lib/x86_64-linux-gnu/libopencv_core.so.4.5d
#4  0x0000555555562e1d in std::_Destroy<cv::Mat> (__pointer=0x5555b4c23920) at /usr/include/c++/9/bits/stl_construct.h:98
#5  0x00005555555626b0 in std::_Destroy_aux<false>::__destroy<cv::Mat*> (__first=0x5555b4c23920, __last=0x5555b4c23980) at /usr/include/c++/9/bits/stl_construct.h:108
#6  0x0000555555561e62 in std::_Destroy<cv::Mat*> (__first=0x5555b4c23920, __last=0x5555b4c23980) at /usr/include/c++/9/bits/stl_construct.h:137
#7  0x00005555555614ad in std::_Destroy<cv::Mat*, cv::Mat> (__first=0x5555b4c23920, __last=0x5555b4c23980) at /usr/include/c++/9/bits/stl_construct.h:206
#8  0x0000555555560b15 in std::vector<cv::Mat, std::allocator<cv::Mat> >::~vector (this=0x7fffffffd660, __in_chrg=<optimized out>) at /usr/include/c++/9/bits/stl_vector.h:677
#9  0x000055555555ef9f in main (argc=5, argv=0x7fffffffdb18) at /home/an/tensorrtx/yolov5/yolov5_seg.cpp:224

```
https://github.com/wang-xinyu/tensorrtx/blob/c66b8b7e2c471f5eba03df9e39cb2b410041be29/yolov5/yolov5_seg.cpp#L224
