### PR TITLE
fix builder->destroy() error in TRT8.6

### DIFF
--- a/yolov5/yolov5_cls.cpp
+++ b/yolov5/yolov5_cls.cpp
@@ -164,9 +164,9 @@ void serialize_engine(unsigned int max_batchsize, float& gd, float& gw, std::str
 
   // Close everything down
   engine->destroy();
-  builder->destroy();
   config->destroy();
   serialized_engine->destroy();
+  builder->destroy();
 }
 
 void deserialize_engine(std::string& engine_name, IRuntime** runtime, ICudaEngine** engine, IExecutionContext** context) {

--- a/yolov5/yolov5_det.cpp
+++ b/yolov5/yolov5_det.cpp
@@ -102,9 +102,9 @@ void serialize_engine(unsigned int max_batchsize, bool& is_p6, float& gd, float&
 
   // Close everything down
   engine->destroy();
-  builder->destroy();
   config->destroy();
   serialized_engine->destroy();
+  builder->destroy();
 }
 
 void deserialize_engine(std::string& engine_name, IRuntime** runtime, ICudaEngine** engine, IExecutionContext** context) {

--- a/yolov5/yolov5_seg.cpp
+++ b/yolov5/yolov5_seg.cpp
@@ -107,9 +107,9 @@ void serialize_engine(unsigned int max_batchsize, float& gd, float& gw, std::str
 
   // Close everything down
   engine->destroy();
-  builder->destroy();
   config->destroy();
   serialized_engine->destroy();
+  builder->destroy();
 }
 
 void deserialize_engine(std::string& engine_name, IRuntime** runtime, ICudaEngine** engine, IExecutionContext** context) {


### PR DESCRIPTION
Operating Environment: nvcr.io/nvidia/tensorrt:23.08-py3 (docker)
If the destroy function of the builder is called before other destroy functions under, an error may occur.