### PR TITLE
修改生成engine文件时的API Usage Error报错

### DIFF
--- a/yolov8/yolov8_det.cpp
+++ b/yolov8/yolov8_det.cpp
@@ -28,9 +28,9 @@ void serialize_engine(std::string &wts_name, std::string &engine_name, std::stri
     }
     p.write(reinterpret_cast<const char *>(serialized_engine->data()), serialized_engine->size());
 
-    delete builder;
     delete config;
     delete serialized_engine;
+    delete builder;
 }
 
 


### PR DESCRIPTION
修改yolov8_det.cpp中serialize_engine函数中释放顺序，解决生成engine文件时的API Usage Error报错