### PR TITLE
Fix object destruction order in APIToModel function to avoid undefined behavior

### DIFF
--- a/mobilenet/mobilenetv2/mobilenet_v2.cpp
+++ b/mobilenet/mobilenetv2/mobilenet_v2.cpp
@@ -245,8 +245,8 @@ void APIToModel(unsigned int maxBatchSize, IHostMemory** modelStream)
 
     // Close everything down
     engine->destroy();
-    builder->destroy();
     config->destroy();
+    builder->destroy();
 }
 
 void doInference(IExecutionContext& context, float* input, float* output, int batchSize)

--- a/mobilenet/mobilenetv3/mobilenet_v3.cpp
+++ b/mobilenet/mobilenetv3/mobilenet_v3.cpp
@@ -384,8 +384,8 @@ void APIToModel(unsigned int maxBatchSize, IHostMemory** modelStream, std::strin
 
     // Close everything down
     engine->destroy();
-    builder->destroy();
     config->destroy();
+    builder->destroy();
 }
 
 void doInference(IExecutionContext& context, float* input, float* output, int batchSize)


### PR DESCRIPTION
### Changes Made
In the `APIToModel` function, the order of object destruction has been fixed. The original code destroyed the engine before the builder, leading to undefined behavior. The destruction order is now corrected by first destroying the engine, followed by the builder.

### Files Modified
I have made changes to the following files:
1. `mobilenetv2/mobilenet_v2.cpp`
2. `mobilenetv3/mobilenet_v3.cpp`

### Original Code
```cpp
engine->destroy();
builder->destroy();
config->destroy();
```

### Modified Code
```cpp
engine->destroy();
config->destroy();
builder->destroy();
```

### Error Message
Without this modification, the following error occurred:
```
[09/27/2024-15:26:37] [E] [TRT] 3: [builder.cpp::~Builder::307] Error Code 3: API Usage Error (Parameter check failed at: optimizer/api/builder.cpp::~Builder::307, condition: mObjectCounter.use_count() == 1. Destroying a builder object before destroying objects it created leads to undefined behavior.)
```

Please review and merge these changes. Thank you!🥰

