### PR TITLE
Add FP16 support for real-esrgan in TensorRT10

### DIFF
--- a/real-esrgan/CMakeLists.txt
+++ b/real-esrgan/CMakeLists.txt
@@ -20,8 +20,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(/usr/local/cuda/include)
 link_directories(/usr/local/cuda/lib64)
 # tensorrt
-include_directories(/usr/include/x86_64-linux-gnu/)
-link_directories(/usr/lib/x86_64-linux-gnu/)
+include_directories(/usr/local/TensorRT-10.10.0.31/include)
+link_directories(/usr/local/TensorRT-10.10.0.31/lib)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Ofast -g -Wfatal-errors -D_MWAITXINTRIN_H_INCLUDED")
 cuda_add_library(myplugins SHARED preprocess.cu postprocess.cu)
@@ -40,5 +40,3 @@ target_link_libraries(real-esrgan ${OpenCV_LIBS})
 if(UNIX)
 add_definitions(-O2 -pthread)
 endif(UNIX)
-
-

--- a/real-esrgan/gen_wts.py
+++ b/real-esrgan/gen_wts.py
@@ -1,15 +1,23 @@
 import argparse
 import os
 import struct
+import numpy as np
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from realesrgan import RealESRGANer
 from realesrgan.archs.srvgg_arch import SRVGGNetCompact
+
+
+def float32_to_float16_hex(value):
+    f16 = np.float16(value)
+    u16 = np.frombuffer(f16.tobytes(), dtype=np.uint16)[0]
+    return format(u16, "04x")
+
 
 def main():
     """Inference demo for Real-ESRGAN.
     """
     parser = argparse.ArgumentParser()
-    #parser.add_argument('-i', '--input', type=str, default='../TestData3', help='Input image or folder')
+    # parser.add_argument('-i', '--input', type=str, default='../TestData3', help='Input image or folder')
     parser.add_argument('-i', '--input', type=str, default='inputs', help='Input image or folder')
     parser.add_argument(
         '-n',
@@ -84,9 +92,13 @@ def main():
             f.write("{} {}".format(k, len(vr)))
             for vv in vr:
                 f.write(" ")
-                f.write(struct.pack(">f", float(vv)).hex())
+                if args.fp32:
+                    f.write(struct.pack(">f", float(vv)).hex())
+                else:
+                    f.write(float32_to_float16_hex(float(vv)))
             f.write("\n")
         print('Completed real-esrgan.wts file!')
+
 
 if __name__ == '__main__':
     main()

--- a/real-esrgan/postprocess.cu
+++ b/real-esrgan/postprocess.cu
@@ -1,14 +1,15 @@
+#include "cublas_v2.h"
 #include "cuda_utils.h"
 
 using namespace std;
 
 // postprocess (NCHW->NHWC, RGB->BGR, *255, ROUND, uint8)
-__global__ void postprocess_kernel(uint8_t* output, float* input,
-    const int batchSize, const int height, const int width, const int channel,
-    const int thread_count)
-{
+template <typename T>
+__global__ void postprocess_kernel(uint8_t* output, const T* input, const int batchSize, const int height,
+                                   const int width, const int channel, const int thread_count) {
     int index = threadIdx.x + blockIdx.x * blockDim.x;
-    if (index >= thread_count) return;
+    if (index >= thread_count)
+        return;
 
     const int c_idx = index % channel;
     int idx = index / channel;
@@ -17,38 +18,57 @@ __global__ void postprocess_kernel(uint8_t* output, float* input,
     const int h_idx = idx % height;
     const int b_idx = idx / height;
 
-    int g_idx = b_idx * height * width * channel + (2 - c_idx)* height * width + h_idx * width + w_idx;
-    float tt = input[g_idx] * 255.f;
+    int g_idx = b_idx * height * width * channel + (2 - c_idx) * height * width + h_idx * width + w_idx;
+    float val = (float)input[g_idx];
+    float tt = val * 255.f;
     if (tt > 255)
         tt = 255;
-    output[index] = tt;
+    if (tt < 0)
+        tt = 0;
+    output[index] = (uint8_t)tt;
 }
 
-void postprocess(uint8_t* output, float*input, int batchSize, int height, int width, int channel, cudaStream_t stream)
-{
+template __global__ void postprocess_kernel<float>(uint8_t* output, const float* input, const int batchSize,
+                                                   const int height, const int width, const int channel,
+                                                   const int thread_count);
+template __global__ void postprocess_kernel<half>(uint8_t* output, const half* input, const int batchSize,
+                                                  const int height, const int width, const int channel,
+                                                  const int thread_count);
+
+template <typename T>
+void postprocess(uint8_t* output, const T* input, int batchSize, int height, int width, int channel,
+                 cudaStream_t stream) {
     int thread_count = batchSize * height * width * channel;
     int block = 512;
     int grid = (thread_count - 1) / block + 1;
 
-    postprocess_kernel << <grid, block, 0, stream >> > (output, input, batchSize, height, width, channel, thread_count);
+    postprocess_kernel<T><<<grid, block, 0, stream>>>(output, input, batchSize, height, width, channel, thread_count);
 }
 
+template void postprocess<float>(uint8_t* output, const float* input, int batchSize, int height, int width, int channel,
+                                 cudaStream_t stream);
+template void postprocess<half>(uint8_t* output, const half* input, int batchSize, int height, int width, int channel,
+                                cudaStream_t stream);
 
 #include "postprocess.hpp"
 
-namespace nvinfer1
-{
-    int PostprocessPluginV2::enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept
-    {
-        float* input = (float*)inputs[0];
-        uint8_t* output = (uint8_t*)outputs[0];
+namespace nvinfer1 {
+int PostprocessPluginV2::enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace,
+                                 cudaStream_t stream) noexcept {
+    uint8_t* output = (uint8_t*)outputs[0];
 
-        const int H = mPostprocess.H;
-        const int W = mPostprocess.W;
-        const int C = mPostprocess.C;
+    const int H = mPostprocess.H;
+    const int W = mPostprocess.W;
+    const int C = mPostprocess.C;
 
-        postprocess(output, input, batchSize, H, W, C, stream);
-
-        return 0;
+    if (mDataType == DataType::kFLOAT) {
+        const float* input = (const float*)inputs[0];
+        postprocess<float>(output, input, batchSize, H, W, C, stream);
+    } else if (mDataType == DataType::kHALF) {
+        const half* input = (const half*)inputs[0];
+        postprocess<half>(output, input, batchSize, H, W, C, stream);
     }
+
+    return 0;
 }
+}  // namespace nvinfer1

--- a/real-esrgan/postprocess.hpp
+++ b/real-esrgan/postprocess.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <NvInfer.h>
+#include <assert.h>
 #include <fstream>
 #include "macros.h"
-#include <assert.h>
 
 struct Postprocess {
     int N;
@@ -11,196 +11,145 @@ struct Postprocess {
     int W;
 };
 
-namespace nvinfer1
-{
-    class PostprocessPluginV2 : public IPluginV2IOExt
-    {
-    public:
-        PostprocessPluginV2(const Postprocess& arg)
-        {
-            mPostprocess = arg;
-        }
+namespace nvinfer1 {
+class PostprocessPluginV2 : public IPluginV2IOExt {
+   public:
+    PostprocessPluginV2(const Postprocess& arg) {
+        mPostprocess = arg;
+        mDataType = DataType::kFLOAT;
+    }
 
-        PostprocessPluginV2(const void* data, size_t length)
-        {
-            const char* d = static_cast<const char*>(data);
-            const char* const a = d;
-            mPostprocess = read<Postprocess>(d);
-            assert(d == a + length);
-        }
-        PostprocessPluginV2() = delete;
+    PostprocessPluginV2(const void* data, size_t length) {
+        const char* d = static_cast<const char*>(data);
+        const char* const a = d;
+        mPostprocess = read<Postprocess>(d);
+        mDataType = read<DataType>(d);
+        assert(d == a + length);
+    }
+    PostprocessPluginV2() = delete;
 
-        virtual ~PostprocessPluginV2() {}
+    virtual ~PostprocessPluginV2() {}
 
-    public:
-        int getNbOutputs() const noexcept override
-        {
-            return 1;
-        }
+   public:
+    int getNbOutputs() const noexcept override { return 1; }
 
-        Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override
-        {
-            return Dims3(mPostprocess.H, mPostprocess.W, mPostprocess.C);
-        }
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
+        return Dims3(mPostprocess.H, mPostprocess.W, mPostprocess.C);
+    }
 
-        int initialize() noexcept override
-        {
-            return 0;
-        }
+    int initialize() noexcept override { return 0; }
 
-        void terminate() noexcept override
-        {
-        }
+    void terminate() noexcept override {}
 
-        size_t getWorkspaceSize(int maxBatchSize) const noexcept override
-        {
-            return 0;
-        }
+    size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-        int enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override;
+    int enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace,
+                cudaStream_t stream) noexcept override;
 
-        size_t getSerializationSize() const noexcept override
-        {
-            size_t serializationSize = 0;
-            serializationSize += sizeof(mPostprocess);
-            return serializationSize;
-        }
+    size_t getSerializationSize() const noexcept override {
+        size_t serializationSize = 0;
+        serializationSize += sizeof(mPostprocess);
+        serializationSize += sizeof(mDataType);
+        return serializationSize;
+    }
 
-        void serialize(void* buffer) const noexcept override
-        {
-            char* d = static_cast<char*>(buffer);
-            const char* const a = d;
-            write(d, mPostprocess);
-            assert(d == a + getSerializationSize());
-        }
+    void serialize(void* buffer) const noexcept override {
+        char* d = static_cast<char*>(buffer);
+        const char* const a = d;
+        write(d, mPostprocess);
+        write(d, mDataType);
+        assert(d == a + getSerializationSize());
+    }
 
-        void configurePlugin(const PluginTensorDesc* in, int nbInput, const PluginTensorDesc* out, int nbOutput) noexcept override
-        {
-        }
+    void configurePlugin(const PluginTensorDesc* in, int nbInput, const PluginTensorDesc* out,
+                         int nbOutput) noexcept override {
+        mDataType = in[0].type;
+    }
 
-        //! The combination of kLINEAR + kINT8/kHALF/kFLOAT is supported.
-        bool supportsFormatCombination(int pos, const PluginTensorDesc* inOut, int nbInputs, int nbOutputs) const noexcept override
-        {
-            assert(nbInputs == 1 && nbOutputs == 1 && pos < nbInputs + nbOutputs);
-            bool condition = inOut[pos].format == TensorFormat::kLINEAR;
-            condition &= inOut[pos].type != DataType::kINT32;
-            condition &= inOut[pos].type == inOut[0].type;
-            return condition;
-        }
+    //! The combination of kLINEAR + kINT8/kHALF/kFLOAT is supported.
+    bool supportsFormatCombination(int pos, const PluginTensorDesc* inOut, int nbInputs,
+                                   int nbOutputs) const noexcept override {
+        assert(nbInputs == 1 && nbOutputs == 1 && pos < nbInputs + nbOutputs);
+        bool condition = inOut[pos].format == TensorFormat::kLINEAR;
+        condition &= inOut[pos].type != DataType::kINT32;
+        condition &= inOut[pos].type == inOut[0].type;
+        return condition;
+    }
 
-        DataType getOutputDataType(int index, const DataType* inputTypes, int nbInputs) const noexcept override
-        {
-            assert(inputTypes && nbInputs == 1);
-            return DataType::kFLOAT; //
-        }
+    DataType getOutputDataType(int index, const DataType* inputTypes, int nbInputs) const noexcept override {
+        assert(inputTypes && nbInputs == 1);
+        return inputTypes[0];
+    }
 
-        const char* getPluginType() const noexcept override
-        {
-            return "postprocess";
-        }
+    const char* getPluginType() const noexcept override { return "postprocess"; }
 
-        const char* getPluginVersion() const noexcept override
-        {
-            return "1";
-        }
+    const char* getPluginVersion() const noexcept override { return "1"; }
 
-        void destroy() noexcept override
-        {
-            delete this;
-        }
+    void destroy() noexcept override { delete this; }
 
-        IPluginV2Ext* clone() const noexcept override
-        {
-            PostprocessPluginV2* plugin = new PostprocessPluginV2(*this);
-            return plugin;
-        }
+    IPluginV2Ext* clone() const noexcept override {
+        PostprocessPluginV2* plugin = new PostprocessPluginV2(*this);
+        return plugin;
+    }
 
-        void setPluginNamespace(const char* libNamespace) noexcept override
-        {
-            mNamespace = libNamespace;
-        }
+    void setPluginNamespace(const char* libNamespace) noexcept override { mNamespace = libNamespace; }
 
-        const char* getPluginNamespace() const noexcept override
-        {
-            return mNamespace.data();
-        }
+    const char* getPluginNamespace() const noexcept override { return mNamespace.data(); }
 
-        bool isOutputBroadcastAcrossBatch(int outputIndex, const bool* inputIsBroadcasted, int nbInputs) const noexcept override
-        {
-            return false;
-        }
+    bool isOutputBroadcastAcrossBatch(int outputIndex, const bool* inputIsBroadcasted,
+                                      int nbInputs) const noexcept override {
+        return false;
+    }
 
-        bool canBroadcastInputAcrossBatch(int inputIndex) const noexcept override
-        {
-            return false;
-        }
+    bool canBroadcastInputAcrossBatch(int inputIndex) const noexcept override { return false; }
 
-    private:
-        template <typename T>
-        void write(char*& buffer, const T& val) const
-        {
-            *reinterpret_cast<T*>(buffer) = val;
-            buffer += sizeof(T);
-        }
+   private:
+    template <typename T>
+    void write(char*& buffer, const T& val) const {
+        *reinterpret_cast<T*>(buffer) = val;
+        buffer += sizeof(T);
+    }
 
-        template <typename T>
-        T read(const char*& buffer) const
-        {
-            T val = *reinterpret_cast<const T*>(buffer);
-            buffer += sizeof(T);
-            return val;
-        }
+    template <typename T>
+    T read(const char*& buffer) const {
+        T val = *reinterpret_cast<const T*>(buffer);
+        buffer += sizeof(T);
+        return val;
+    }
 
-    private:
-        Postprocess mPostprocess;
-        std::string mNamespace;
-    };
-
-    class PostprocessPluginV2Creator : public IPluginCreator
-    {
-    public:
-        const char* getPluginName() const noexcept override
-        {
-            return "postprocess";
-        }
-
-        const char* getPluginVersion() const noexcept override
-        {
-            return "1";
-        }
-
-        const PluginFieldCollection* getFieldNames() noexcept override
-        {
-            return nullptr;
-        }
-
-        IPluginV2* createPlugin(const char* name, const PluginFieldCollection* fc) noexcept override
-        {
-            PostprocessPluginV2* plugin = new PostprocessPluginV2(*(Postprocess*)fc);
-            mPluginName = name;
-            return plugin;
-        }
-
-        IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override
-        {
-            auto plugin = new PostprocessPluginV2(serialData, serialLength);
-            mPluginName = name;
-            return plugin;
-        }
-
-        void setPluginNamespace(const char* libNamespace) noexcept override
-        {
-            mNamespace = libNamespace;
-        }
-
-        const char* getPluginNamespace() const noexcept override
-        {
-            return mNamespace.c_str();
-        }
-
-    private:
-        std::string mNamespace;
-        std::string mPluginName;
-    };
-    REGISTER_TENSORRT_PLUGIN(PostprocessPluginV2Creator);
+   private:
+    Postprocess mPostprocess;
+    DataType mDataType;
+    std::string mNamespace;
 };
+
+class PostprocessPluginV2Creator : public IPluginCreator {
+   public:
+    const char* getPluginName() const noexcept override { return "postprocess"; }
+
+    const char* getPluginVersion() const noexcept override { return "1"; }
+
+    const PluginFieldCollection* getFieldNames() noexcept override { return nullptr; }
+
+    IPluginV2* createPlugin(const char* name, const PluginFieldCollection* fc) noexcept override {
+        PostprocessPluginV2* plugin = new PostprocessPluginV2(*(Postprocess*)fc);
+        mPluginName = name;
+        return plugin;
+    }
+
+    IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+        auto plugin = new PostprocessPluginV2(serialData, serialLength);
+        mPluginName = name;
+        return plugin;
+    }
+
+    void setPluginNamespace(const char* libNamespace) noexcept override { mNamespace = libNamespace; }
+
+    const char* getPluginNamespace() const noexcept override { return mNamespace.c_str(); }
+
+   private:
+    std::string mNamespace;
+    std::string mPluginName;
+};
+REGISTER_TENSORRT_PLUGIN(PostprocessPluginV2Creator);
+};  // namespace nvinfer1

--- a/real-esrgan/preprocess.cu
+++ b/real-esrgan/preprocess.cu
@@ -1,14 +1,15 @@
+#include "cublas_v2.h"
 #include "cuda_utils.h"
 
 using namespace std;
 
 // preprocess (NHWC->NCHW, BGR->RGB, [0, 255]->[0, 1](Normalize))
-__global__ void preprocess_kernel(float* output, uint8_t* input,
-    const int batchSize, const int height, const int width, const int channel,
-    const int thread_count)
-{
+template <typename T>
+__global__ void preprocess_kernel(T* output, uint8_t* input, const int batchSize, const int height, const int width,
+                                  const int channel, const int thread_count) {
     int index = threadIdx.x + blockIdx.x * blockDim.x;
-    if (index >= thread_count) return;
+    if (index >= thread_count)
+        return;
 
     const int w_idx = index % width;
     int idx = index / width;
@@ -19,33 +20,48 @@ __global__ void preprocess_kernel(float* output, uint8_t* input,
 
     int g_idx = b_idx * height * width * channel + h_idx * width * channel + w_idx * channel + 2 - c_idx;
 
-    output[index] = input[g_idx] / 255.f;
+    float val = input[g_idx] / 255.f;
+    output[index] = (T)val;
 }
 
-void preprocess(float* output, uint8_t*input, int batchSize, int height, int width, int channel, cudaStream_t stream)
-{
+template __global__ void preprocess_kernel<float>(float* output, uint8_t* input, const int batchSize, const int height,
+                                                  const int width, const int channel, const int thread_count);
+template __global__ void preprocess_kernel<half>(half* output, uint8_t* input, const int batchSize, const int height,
+                                                 const int width, const int channel, const int thread_count);
+
+template <typename T>
+void preprocess(T* output, uint8_t* input, int batchSize, int height, int width, int channel, cudaStream_t stream) {
     int thread_count = batchSize * height * width * channel;
     int block = 512;
     int grid = (thread_count - 1) / block + 1;
 
-    preprocess_kernel << <grid, block, 0, stream >> > (output, input, batchSize, height, width, channel, thread_count);
+    preprocess_kernel<T><<<grid, block, 0, stream>>>(output, input, batchSize, height, width, channel, thread_count);
 }
+
+template void preprocess<float>(float* output, uint8_t* input, int batchSize, int height, int width, int channel,
+                                cudaStream_t stream);
+template void preprocess<half>(half* output, uint8_t* input, int batchSize, int height, int width, int channel,
+                               cudaStream_t stream);
 
 #include "preprocess.hpp"
 
-namespace nvinfer1
-{
-    int PreprocessPluginV2::enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept
-    {
-        uint8_t* input = (uint8_t*)inputs[0];
+namespace nvinfer1 {
+int PreprocessPluginV2::enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace,
+                                cudaStream_t stream) noexcept {
+    uint8_t* input = (uint8_t*)inputs[0];
+
+    const int H = mPreprocess.H;
+    const int W = mPreprocess.W;
+    const int C = mPreprocess.C;
+
+    if (mDataType == DataType::kFLOAT) {
         float* output = (float*)outputs[0];
-
-        const int H = mPreprocess.H;
-        const int W = mPreprocess.W;
-        const int C = mPreprocess.C;
-
-        preprocess(output, input, batchSize, H, W, C, stream);
-
-        return 0;
+        preprocess<float>(output, input, batchSize, H, W, C, stream);
+    } else if (mDataType == DataType::kHALF) {
+        half* output = (half*)outputs[0];
+        preprocess<half>(output, input, batchSize, H, W, C, stream);
     }
+
+    return 0;
 }
+}  // namespace nvinfer1

--- a/real-esrgan/preprocess.hpp
+++ b/real-esrgan/preprocess.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <NvInfer.h>
+#include <assert.h>
 #include <fstream>
 #include "macros.h"
-#include <assert.h>
 
 struct Preprocess {
     int N;
@@ -11,196 +11,145 @@ struct Preprocess {
     int W;
 };
 
-namespace nvinfer1
-{
-    class PreprocessPluginV2 : public IPluginV2IOExt
-    {
-    public:
-        PreprocessPluginV2(const Preprocess& arg)
-        {
-            mPreprocess = arg;
-        }
+namespace nvinfer1 {
+class PreprocessPluginV2 : public IPluginV2IOExt {
+   public:
+    PreprocessPluginV2(const Preprocess& arg) {
+        mPreprocess = arg;
+        mDataType = DataType::kFLOAT;
+    }
 
-        PreprocessPluginV2(const void* data, size_t length)
-        {
-            const char* d = static_cast<const char*>(data);
-            const char* const a = d;
-            mPreprocess = read<Preprocess>(d);
-            assert(d == a + length);
-        }
-        PreprocessPluginV2() = delete;
+    PreprocessPluginV2(const void* data, size_t length) {
+        const char* d = static_cast<const char*>(data);
+        const char* const a = d;
+        mPreprocess = read<Preprocess>(d);
+        mDataType = read<DataType>(d);
+        assert(d == a + length);
+    }
+    PreprocessPluginV2() = delete;
 
-        virtual ~PreprocessPluginV2() {}
+    virtual ~PreprocessPluginV2() {}
 
-    public:
-        int getNbOutputs() const noexcept override
-        {
-            return 1;
-        }
+   public:
+    int getNbOutputs() const noexcept override { return 1; }
 
-        Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override
-        {
-            return Dims3(mPreprocess.C, mPreprocess.H, mPreprocess.W);
-        }
+    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) noexcept override {
+        return Dims3(mPreprocess.C, mPreprocess.H, mPreprocess.W);
+    }
 
-        int initialize() noexcept override
-        {
-            return 0;
-        }
+    int initialize() noexcept override { return 0; }
 
-        void terminate() noexcept override
-        {
-        }
+    void terminate() noexcept override {}
 
-        size_t getWorkspaceSize(int maxBatchSize) const noexcept override
-        {
-            return 0;
-        }
+    size_t getWorkspaceSize(int maxBatchSize) const noexcept override { return 0; }
 
-        int enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override;
+    int enqueue(int batchSize, const void* const* inputs, void* const* outputs, void* workspace,
+                cudaStream_t stream) noexcept override;
 
-        size_t getSerializationSize() const noexcept override
-        {
-            size_t serializationSize = 0;
-            serializationSize += sizeof(mPreprocess);
-            return serializationSize;
-        }
+    size_t getSerializationSize() const noexcept override {
+        size_t serializationSize = 0;
+        serializationSize += sizeof(mPreprocess);
+        serializationSize += sizeof(mDataType);
+        return serializationSize;
+    }
 
-        void serialize(void* buffer) const noexcept override
-        {
-            char* d = static_cast<char*>(buffer);
-            const char* const a = d;
-            write(d, mPreprocess);
-            assert(d == a + getSerializationSize());
-        }
+    void serialize(void* buffer) const noexcept override {
+        char* d = static_cast<char*>(buffer);
+        const char* const a = d;
+        write(d, mPreprocess);
+        write(d, mDataType);
+        assert(d == a + getSerializationSize());
+    }
 
-        void configurePlugin(const PluginTensorDesc* in, int nbInput, const PluginTensorDesc* out, int nbOutput) noexcept override
-        {
-        }
+    void configurePlugin(const PluginTensorDesc* in, int nbInput, const PluginTensorDesc* out,
+                         int nbOutput) noexcept override {
+        mDataType = in[0].type;
+    }
 
-        //! The combination of kLINEAR + kINT8/kHALF/kFLOAT is supported.
-        bool supportsFormatCombination(int pos, const PluginTensorDesc* inOut, int nbInputs, int nbOutputs) const noexcept override
-        {
-            assert(nbInputs == 1 && nbOutputs == 1 && pos < nbInputs + nbOutputs);
-            bool condition = inOut[pos].format == TensorFormat::kLINEAR;
-            condition &= inOut[pos].type != DataType::kINT32;
-            condition &= inOut[pos].type == inOut[0].type;
-            return condition;
-        }
+    //! The combination of kLINEAR + kINT8/kHALF/kFLOAT is supported.
+    bool supportsFormatCombination(int pos, const PluginTensorDesc* inOut, int nbInputs,
+                                   int nbOutputs) const noexcept override {
+        assert(nbInputs == 1 && nbOutputs == 1 && pos < nbInputs + nbOutputs);
+        bool condition = inOut[pos].format == TensorFormat::kLINEAR;
+        condition &= inOut[pos].type != DataType::kINT32;
+        condition &= inOut[pos].type == inOut[0].type;
+        return condition;
+    }
 
-        DataType getOutputDataType(int index, const DataType* inputTypes, int nbInputs) const noexcept override
-        {
-            assert(inputTypes && nbInputs == 1);
-            return DataType::kFLOAT; //
-        }
+    DataType getOutputDataType(int index, const DataType* inputTypes, int nbInputs) const noexcept override {
+        assert(inputTypes && nbInputs == 1);
+        return inputTypes[0];
+    }
 
-        const char* getPluginType() const noexcept override
-        {
-            return "preprocess";
-        }
+    const char* getPluginType() const noexcept override { return "preprocess"; }
 
-        const char* getPluginVersion() const noexcept override
-        {
-            return "1";
-        }
+    const char* getPluginVersion() const noexcept override { return "1"; }
 
-        void destroy() noexcept override
-        {
-            delete this;
-        }
+    void destroy() noexcept override { delete this; }
 
-        IPluginV2Ext* clone() const noexcept override
-        {
-            PreprocessPluginV2* plugin = new PreprocessPluginV2(*this);
-            return plugin;
-        }
+    IPluginV2Ext* clone() const noexcept override {
+        PreprocessPluginV2* plugin = new PreprocessPluginV2(*this);
+        return plugin;
+    }
 
-        void setPluginNamespace(const char* libNamespace) noexcept override
-        {
-            mNamespace = libNamespace;
-        }
+    void setPluginNamespace(const char* libNamespace) noexcept override { mNamespace = libNamespace; }
 
-        const char* getPluginNamespace() const noexcept override
-        {
-            return mNamespace.data();
-        }
+    const char* getPluginNamespace() const noexcept override { return mNamespace.data(); }
 
-        bool isOutputBroadcastAcrossBatch(int outputIndex, const bool* inputIsBroadcasted, int nbInputs) const noexcept override
-        {
-            return false;
-        }
+    bool isOutputBroadcastAcrossBatch(int outputIndex, const bool* inputIsBroadcasted,
+                                      int nbInputs) const noexcept override {
+        return false;
+    }
 
-        bool canBroadcastInputAcrossBatch(int inputIndex) const noexcept override
-        {
-            return false;
-        }
+    bool canBroadcastInputAcrossBatch(int inputIndex) const noexcept override { return false; }
 
-    private:
-        template <typename T>
-        void write(char*& buffer, const T& val) const
-        {
-            *reinterpret_cast<T*>(buffer) = val;
-            buffer += sizeof(T);
-        }
+   private:
+    template <typename T>
+    void write(char*& buffer, const T& val) const {
+        *reinterpret_cast<T*>(buffer) = val;
+        buffer += sizeof(T);
+    }
 
-        template <typename T>
-        T read(const char*& buffer) const
-        {
-            T val = *reinterpret_cast<const T*>(buffer);
-            buffer += sizeof(T);
-            return val;
-        }
+    template <typename T>
+    T read(const char*& buffer) const {
+        T val = *reinterpret_cast<const T*>(buffer);
+        buffer += sizeof(T);
+        return val;
+    }
 
-    private:
-        Preprocess mPreprocess;
-        std::string mNamespace;
-    };
-
-    class PreprocessPluginV2Creator : public IPluginCreator
-    {
-    public:
-        const char* getPluginName() const noexcept override
-        {
-            return "preprocess";
-        }
-
-        const char* getPluginVersion() const noexcept override
-        {
-            return "1";
-        }
-
-        const PluginFieldCollection* getFieldNames() noexcept override
-        {
-            return nullptr;
-        }
-
-        IPluginV2* createPlugin(const char* name, const PluginFieldCollection* fc) noexcept override
-        {
-            PreprocessPluginV2* plugin = new PreprocessPluginV2(*(Preprocess*)fc);
-            mPluginName = name;
-            return plugin;
-        }
-
-        IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override
-        {
-            auto plugin = new PreprocessPluginV2(serialData, serialLength);
-            mPluginName = name;
-            return plugin;
-        }
-
-        void setPluginNamespace(const char* libNamespace) noexcept override
-        {
-            mNamespace = libNamespace;
-        }
-
-        const char* getPluginNamespace() const noexcept override
-        {
-            return mNamespace.c_str();
-        }
-
-    private:
-        std::string mNamespace;
-        std::string mPluginName;
-    };
-    REGISTER_TENSORRT_PLUGIN(PreprocessPluginV2Creator);
+   private:
+    Preprocess mPreprocess;
+    DataType mDataType;
+    std::string mNamespace;
 };
+
+class PreprocessPluginV2Creator : public IPluginCreator {
+   public:
+    const char* getPluginName() const noexcept override { return "preprocess"; }
+
+    const char* getPluginVersion() const noexcept override { return "1"; }
+
+    const PluginFieldCollection* getFieldNames() noexcept override { return nullptr; }
+
+    IPluginV2* createPlugin(const char* name, const PluginFieldCollection* fc) noexcept override {
+        PreprocessPluginV2* plugin = new PreprocessPluginV2(*(Preprocess*)fc);
+        mPluginName = name;
+        return plugin;
+    }
+
+    IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+        auto plugin = new PreprocessPluginV2(serialData, serialLength);
+        mPluginName = name;
+        return plugin;
+    }
+
+    void setPluginNamespace(const char* libNamespace) noexcept override { mNamespace = libNamespace; }
+
+    const char* getPluginNamespace() const noexcept override { return mNamespace.c_str(); }
+
+   private:
+    std::string mNamespace;
+    std::string mPluginName;
+};
+REGISTER_TENSORRT_PLUGIN(PreprocessPluginV2Creator);
+};  // namespace nvinfer1


### PR DESCRIPTION
## OverView

### Breaking Changes:
- Add FP16 support for real-esrgan in TensorRT10

### Test Result
Implemented FP16 support based on TensorRT10. Benchmarking shows a substantial reduction in inference latency:
- **FP32 Latency:** 1250 ms per image
- **FP16 Latency:** 404 ms per image (**3x faster**)