### PR TITLE
upgrade mobilenetv3 to tensorrt 10

### DIFF
--- a/mobilenet/mobilenetv3/CMakeLists.txt
+++ b/mobilenet/mobilenetv3/CMakeLists.txt
@@ -19,9 +19,13 @@ link_directories(/usr/local/cuda/lib64)
 include_directories(/usr/include/x86_64-linux-gnu/)
 link_directories(/usr/lib/x86_64-linux-gnu/)
 
+# Find OpenCV
+find_package(OpenCV REQUIRED)
+
 add_executable(mobilenetv3  ${PROJECT_SOURCE_DIR}/mobilenet_v3.cpp)
+target_include_directories(mobilenetv3 PRIVATE ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(mobilenetv3 nvinfer)
 target_link_libraries(mobilenetv3 cudart)
+target_link_libraries(mobilenetv3 ${OpenCV_LIBS})
 
 add_definitions(-O2 -pthread)
-

--- a/mobilenet/mobilenetv3/README.md
+++ b/mobilenet/mobilenetv3/README.md
@@ -15,12 +15,14 @@ For the Pytorch implementation, you can refer to [mobilenetv3.pytorch](https://g
 
 ```
 cd tensorrtx/mobilenet/mobilenetv3
+sudo apt install libopencv-dev -y
 mkdir build
 cd build
 cmake ..
 make
-sudo ./mobilenetv3 -s small(or large) // serialize model to plan file i.e. 'mobilenetv3_small.engine'
-sudo ./mobilenetv3 -d small(or large)  // deserialize plan file and run inference
+sudo ./mobilenetv3 -s small(or large)             // serialize model to plan file i.e. 'mobilenetv3_small.engine'
+sudo ./mobilenetv3 -d small(or large)             // deserialize plan file and run inference
+sudo ./mobilenetv3 -d small(or large) image.jpg   // deserialize plan file and run inference on an image
 ```
 
 4. see if the output is same as pytorch side
@@ -36,7 +38,8 @@ sudo ./mobilenetv3 -d small(or large)  // deserialize plan file and run inferenc
 
 cd tensorrtx/mobilenet/mobilenetv3
 
-python mobilenet_v2.py -s small(or large)  // serialize model to plan file i.e. 'mobilenetv2.engine'
-python mobilenet_v2.py -d small(or large)  // deserialize plan file and run inference
+python mobilenet_v2.py -s small(or large)                        // serialize model to plan file i.e. 'mobilenetv2.engine'
+python mobilenet_v2.py -d small(or large)                        // deserialize plan file and run inference
+python mobilenet_v2.py -d small(or large) --image image.jpg      // deserialize plan file and run inference on an image
 
 ```

--- a/mobilenet/mobilenetv3/logging.h
+++ b/mobilenet/mobilenetv3/logging.h
@@ -17,7 +17,6 @@
 #ifndef TENSORRT_LOGGING_H
 #define TENSORRT_LOGGING_H
 
-#include "NvInferRuntimeCommon.h"
 #include <cassert>
 #include <ctime>
 #include <iomanip>
@@ -25,32 +24,23 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include "NvInferRuntimeCommon.h"
 
 using Severity = nvinfer1::ILogger::Severity;
 
-class LogStreamConsumerBuffer : public std::stringbuf
-{
-public:
+class LogStreamConsumerBuffer : public std::stringbuf {
+   public:
     LogStreamConsumerBuffer(std::ostream& stream, const std::string& prefix, bool shouldLog)
-        : mOutput(stream)
-        , mPrefix(prefix)
-        , mShouldLog(shouldLog)
-    {
-    }
+        : mOutput(stream), mPrefix(prefix), mShouldLog(shouldLog) {}
 
-    LogStreamConsumerBuffer(LogStreamConsumerBuffer&& other)
-        : mOutput(other.mOutput)
-    {
-    }
+    LogStreamConsumerBuffer(LogStreamConsumerBuffer&& other) : mOutput(other.mOutput) {}
 
-    ~LogStreamConsumerBuffer()
-    {
+    ~LogStreamConsumerBuffer() {
         // std::streambuf::pbase() gives a pointer to the beginning of the buffered part of the output sequence
         // std::streambuf::pptr() gives a pointer to the current position of the output sequence
         // if the pointer to the beginning is not equal to the pointer to the current position,
         // call putOutput() to log the output to the stream
-        if (pbase() != pptr())
-        {
+        if (pbase() != pptr()) {
             putOutput();
         }
     }
@@ -58,16 +48,13 @@ public:
     // synchronizes the stream buffer and returns 0 on success
     // synchronizing the stream buffer consists of inserting the buffer contents into the stream,
     // resetting the buffer and flushing the stream
-    virtual int sync()
-    {
+    virtual int sync() {
         putOutput();
         return 0;
     }
 
-    void putOutput()
-    {
-        if (mShouldLog)
-        {
+    void putOutput() {
+        if (mShouldLog) {
             // prepend timestamp
             std::time_t timestamp = std::time(nullptr);
             tm* tm_local = std::localtime(&timestamp);
@@ -88,12 +75,9 @@ public:
         }
     }
 
-    void setShouldLog(bool shouldLog)
-    {
-        mShouldLog = shouldLog;
-    }
+    void setShouldLog(bool shouldLog) { mShouldLog = shouldLog; }
 
-private:
+   private:
     std::ostream& mOutput;
     std::string mPrefix;
     bool mShouldLog;
@@ -103,15 +87,12 @@ private:
 //! \class LogStreamConsumerBase
 //! \brief Convenience object used to initialize LogStreamConsumerBuffer before std::ostream in LogStreamConsumer
 //!
-class LogStreamConsumerBase
-{
-public:
+class LogStreamConsumerBase {
+   public:
     LogStreamConsumerBase(std::ostream& stream, const std::string& prefix, bool shouldLog)
-        : mBuffer(stream, prefix, shouldLog)
-    {
-    }
+        : mBuffer(stream, prefix, shouldLog) {}
 
-protected:
+   protected:
     LogStreamConsumerBuffer mBuffer;
 };
 
@@ -124,49 +105,49 @@ protected:
 //!  This is necessary to prevent the address of an uninitialized buffer from being passed to std::ostream.
 //!  Please do not change the order of the parent classes.
 //!
-class LogStreamConsumer : protected LogStreamConsumerBase, public std::ostream
-{
-public:
+class LogStreamConsumer : protected LogStreamConsumerBase, public std::ostream {
+   public:
     //! \brief Creates a LogStreamConsumer which logs messages with level severity.
     //!  Reportable severity determines if the messages are severe enough to be logged.
     LogStreamConsumer(Severity reportableSeverity, Severity severity)
-        : LogStreamConsumerBase(severityOstream(severity), severityPrefix(severity), severity <= reportableSeverity)
-        , std::ostream(&mBuffer) // links the stream buffer with the stream
-        , mShouldLog(severity <= reportableSeverity)
-        , mSeverity(severity)
-    {
-    }
+        : LogStreamConsumerBase(severityOstream(severity), severityPrefix(severity), severity <= reportableSeverity),
+          std::ostream(&mBuffer)  // links the stream buffer with the stream
+          ,
+          mShouldLog(severity <= reportableSeverity),
+          mSeverity(severity) {}
 
     LogStreamConsumer(LogStreamConsumer&& other)
-        : LogStreamConsumerBase(severityOstream(other.mSeverity), severityPrefix(other.mSeverity), other.mShouldLog)
-        , std::ostream(&mBuffer) // links the stream buffer with the stream
-        , mShouldLog(other.mShouldLog)
-        , mSeverity(other.mSeverity)
-    {
-    }
+        : LogStreamConsumerBase(severityOstream(other.mSeverity), severityPrefix(other.mSeverity), other.mShouldLog),
+          std::ostream(&mBuffer)  // links the stream buffer with the stream
+          ,
+          mShouldLog(other.mShouldLog),
+          mSeverity(other.mSeverity) {}
 
-    void setReportableSeverity(Severity reportableSeverity)
-    {
+    void setReportableSeverity(Severity reportableSeverity) {
         mShouldLog = mSeverity <= reportableSeverity;
         mBuffer.setShouldLog(mShouldLog);
     }
 
-private:
-    static std::ostream& severityOstream(Severity severity)
-    {
+   private:
+    static std::ostream& severityOstream(Severity severity) {
         return severity >= Severity::kINFO ? std::cout : std::cerr;
     }
 
-    static std::string severityPrefix(Severity severity)
-    {
-        switch (severity)
-        {
-        case Severity::kINTERNAL_ERROR: return "[F] ";
-        case Severity::kERROR: return "[E] ";
-        case Severity::kWARNING: return "[W] ";
-        case Severity::kINFO: return "[I] ";
-        case Severity::kVERBOSE: return "[V] ";
-        default: assert(0); return "";
+    static std::string severityPrefix(Severity severity) {
+        switch (severity) {
+            case Severity::kINTERNAL_ERROR:
+                return "[F] ";
+            case Severity::kERROR:
+                return "[E] ";
+            case Severity::kWARNING:
+                return "[W] ";
+            case Severity::kINFO:
+                return "[I] ";
+            case Severity::kVERBOSE:
+                return "[V] ";
+            default:
+                assert(0);
+                return "";
         }
     }
 
@@ -198,24 +179,19 @@ private:
 //! class to eliminate the inheritance and instead make the nvinfer1::ILogger implementation a member of the Logger
 //! object.
 
-class Logger : public nvinfer1::ILogger
-{
-public:
-    Logger(Severity severity = Severity::kWARNING)
-        : mReportableSeverity(severity)
-    {
-    }
+class Logger : public nvinfer1::ILogger {
+   public:
+    Logger(Severity severity = Severity::kWARNING) : mReportableSeverity(severity) {}
 
     //!
     //! \enum TestResult
     //! \brief Represents the state of a given test
     //!
-    enum class TestResult
-    {
-        kRUNNING, //!< The test is running
-        kPASSED,  //!< The test passed
-        kFAILED,  //!< The test failed
-        kWAIVED   //!< The test was waived
+    enum class TestResult {
+        kRUNNING,  //!< The test is running
+        kPASSED,   //!< The test passed
+        kFAILED,   //!< The test failed
+        kWAIVED    //!< The test was waived
     };
 
     //!
@@ -225,10 +201,7 @@ public:
     //! TODO Once all samples are updated to use this method to register the logger with TensorRT,
     //! we can eliminate the inheritance of Logger from ILogger
     //!
-    nvinfer1::ILogger& getTRTLogger()
-    {
-        return *this;
-    }
+    nvinfer1::ILogger& getTRTLogger() { return *this; }
 
     //!
     //! \brief Implementation of the nvinfer1::ILogger::log() virtual method
@@ -236,8 +209,7 @@ public:
     //! Note samples should not be calling this function directly; it will eventually go away once we eliminate the
     //! inheritance from nvinfer1::ILogger
     //!
-    void log(Severity severity, const char* msg) override
-    {
+    void log(Severity severity, const char* msg) noexcept override {
         LogStreamConsumer(mReportableSeverity, severity) << "[TRT] " << std::string(msg) << std::endl;
     }
 
@@ -246,10 +218,7 @@ public:
     //!
     //! \param severity The logger will only emit messages that have severity of this level or higher.
     //!
-    void setReportableSeverity(Severity severity)
-    {
-        mReportableSeverity = severity;
-    }
+    void setReportableSeverity(Severity severity) { mReportableSeverity = severity; }
 
     //!
     //! \brief Opaque handle that holds logging information for a particular test
@@ -258,20 +227,15 @@ public:
     //! The sample must call Logger::defineTest() in order to obtain a TestAtom that can be used
     //! with Logger::reportTest{Start,End}().
     //!
-    class TestAtom
-    {
-    public:
+    class TestAtom {
+       public:
         TestAtom(TestAtom&&) = default;
 
-    private:
+       private:
         friend class Logger;
 
         TestAtom(bool started, const std::string& name, const std::string& cmdline)
-            : mStarted(started)
-            , mName(name)
-            , mCmdline(cmdline)
-        {
-        }
+            : mStarted(started), mName(name), mCmdline(cmdline) {}
 
         bool mStarted;
         std::string mName;
@@ -289,8 +253,7 @@ public:
     //
     //! \return a TestAtom that can be used in Logger::reportTest{Start,End}().
     //!
-    static TestAtom defineTest(const std::string& name, const std::string& cmdline)
-    {
+    static TestAtom defineTest(const std::string& name, const std::string& cmdline) {
         return TestAtom(false, name, cmdline);
     }
 
@@ -303,8 +266,7 @@ public:
     //! \param[in] argv The array of command-line arguments (given as C strings)
     //!
     //! \return a TestAtom that can be used in Logger::reportTest{Start,End}().
-    static TestAtom defineTest(const std::string& name, int argc, char const* const* argv)
-    {
+    static TestAtom defineTest(const std::string& name, int argc, char const* const* argv) {
         auto cmdline = genCmdlineString(argc, argv);
         return defineTest(name, cmdline);
     }
@@ -316,8 +278,7 @@ public:
     //!
     //! \param[in] testAtom The handle to the test that has started
     //!
-    static void reportTestStart(TestAtom& testAtom)
-    {
+    static void reportTestStart(TestAtom& testAtom) {
         reportTestResult(testAtom, TestResult::kRUNNING);
         assert(!testAtom.mStarted);
         testAtom.mStarted = true;
@@ -332,86 +293,85 @@ public:
     //! \param[in] result The result of the test. Should be one of TestResult::kPASSED,
     //!                   TestResult::kFAILED, TestResult::kWAIVED
     //!
-    static void reportTestEnd(const TestAtom& testAtom, TestResult result)
-    {
+    static void reportTestEnd(const TestAtom& testAtom, TestResult result) {
         assert(result != TestResult::kRUNNING);
         assert(testAtom.mStarted);
         reportTestResult(testAtom, result);
     }
 
-    static int reportPass(const TestAtom& testAtom)
-    {
+    static int reportPass(const TestAtom& testAtom) {
         reportTestEnd(testAtom, TestResult::kPASSED);
         return EXIT_SUCCESS;
     }
 
-    static int reportFail(const TestAtom& testAtom)
-    {
+    static int reportFail(const TestAtom& testAtom) {
         reportTestEnd(testAtom, TestResult::kFAILED);
         return EXIT_FAILURE;
     }
 
-    static int reportWaive(const TestAtom& testAtom)
-    {
+    static int reportWaive(const TestAtom& testAtom) {
         reportTestEnd(testAtom, TestResult::kWAIVED);
         return EXIT_SUCCESS;
     }
 
-    static int reportTest(const TestAtom& testAtom, bool pass)
-    {
+    static int reportTest(const TestAtom& testAtom, bool pass) {
         return pass ? reportPass(testAtom) : reportFail(testAtom);
     }
 
-    Severity getReportableSeverity() const
-    {
-        return mReportableSeverity;
-    }
+    Severity getReportableSeverity() const { return mReportableSeverity; }
 
-private:
+   private:
     //!
     //! \brief returns an appropriate string for prefixing a log message with the given severity
     //!
-    static const char* severityPrefix(Severity severity)
-    {
-        switch (severity)
-        {
-        case Severity::kINTERNAL_ERROR: return "[F] ";
-        case Severity::kERROR: return "[E] ";
-        case Severity::kWARNING: return "[W] ";
-        case Severity::kINFO: return "[I] ";
-        case Severity::kVERBOSE: return "[V] ";
-        default: assert(0); return "";
+    static const char* severityPrefix(Severity severity) {
+        switch (severity) {
+            case Severity::kINTERNAL_ERROR:
+                return "[F] ";
+            case Severity::kERROR:
+                return "[E] ";
+            case Severity::kWARNING:
+                return "[W] ";
+            case Severity::kINFO:
+                return "[I] ";
+            case Severity::kVERBOSE:
+                return "[V] ";
+            default:
+                assert(0);
+                return "";
         }
     }
 
     //!
     //! \brief returns an appropriate string for prefixing a test result message with the given result
     //!
-    static const char* testResultString(TestResult result)
-    {
-        switch (result)
-        {
-        case TestResult::kRUNNING: return "RUNNING";
-        case TestResult::kPASSED: return "PASSED";
-        case TestResult::kFAILED: return "FAILED";
-        case TestResult::kWAIVED: return "WAIVED";
-        default: assert(0); return "";
+    static const char* testResultString(TestResult result) {
+        switch (result) {
+            case TestResult::kRUNNING:
+                return "RUNNING";
+            case TestResult::kPASSED:
+                return "PASSED";
+            case TestResult::kFAILED:
+                return "FAILED";
+            case TestResult::kWAIVED:
+                return "WAIVED";
+            default:
+                assert(0);
+                return "";
         }
     }
 
     //!
     //! \brief returns an appropriate output stream (cout or cerr) to use with the given severity
     //!
-    static std::ostream& severityOstream(Severity severity)
-    {
+    static std::ostream& severityOstream(Severity severity) {
         return severity >= Severity::kINFO ? std::cout : std::cerr;
     }
 
     //!
     //! \brief method that implements logging test results
     //!
-    static void reportTestResult(const TestAtom& testAtom, TestResult result)
-    {
+    static void reportTestResult(const TestAtom& testAtom, TestResult result) {
         severityOstream(Severity::kINFO) << "&&&& " << testResultString(result) << " " << testAtom.mName << " # "
                                          << testAtom.mCmdline << std::endl;
     }
@@ -419,11 +379,9 @@ private:
     //!
     //! \brief generate a command line string from the given (argc, argv) values
     //!
-    static std::string genCmdlineString(int argc, char const* const* argv)
-    {
+    static std::string genCmdlineString(int argc, char const* const* argv) {
         std::stringstream ss;
-        for (int i = 0; i < argc; i++)
-        {
+        for (int i = 0; i < argc; i++) {
             if (i > 0)
                 ss << " ";
             ss << argv[i];
@@ -434,8 +392,7 @@ private:
     Severity mReportableSeverity;
 };
 
-namespace
-{
+namespace {
 
 //!
 //! \brief produces a LogStreamConsumer object that can be used to log messages of severity kVERBOSE
@@ -444,8 +401,7 @@ namespace
 //!
 //!     LOG_VERBOSE(logger) << "hello world" << std::endl;
 //!
-inline LogStreamConsumer LOG_VERBOSE(const Logger& logger)
-{
+inline LogStreamConsumer LOG_VERBOSE(const Logger& logger) {
     return LogStreamConsumer(logger.getReportableSeverity(), Severity::kVERBOSE);
 }
 
@@ -456,8 +412,7 @@ inline LogStreamConsumer LOG_VERBOSE(const Logger& logger)
 //!
 //!     LOG_INFO(logger) << "hello world" << std::endl;
 //!
-inline LogStreamConsumer LOG_INFO(const Logger& logger)
-{
+inline LogStreamConsumer LOG_INFO(const Logger& logger) {
     return LogStreamConsumer(logger.getReportableSeverity(), Severity::kINFO);
 }
 
@@ -468,8 +423,7 @@ inline LogStreamConsumer LOG_INFO(const Logger& logger)
 //!
 //!     LOG_WARN(logger) << "hello world" << std::endl;
 //!
-inline LogStreamConsumer LOG_WARN(const Logger& logger)
-{
+inline LogStreamConsumer LOG_WARN(const Logger& logger) {
     return LogStreamConsumer(logger.getReportableSeverity(), Severity::kWARNING);
 }
 
@@ -480,8 +434,7 @@ inline LogStreamConsumer LOG_WARN(const Logger& logger)
 //!
 //!     LOG_ERROR(logger) << "hello world" << std::endl;
 //!
-inline LogStreamConsumer LOG_ERROR(const Logger& logger)
-{
+inline LogStreamConsumer LOG_ERROR(const Logger& logger) {
     return LogStreamConsumer(logger.getReportableSeverity(), Severity::kERROR);
 }
 
@@ -493,11 +446,10 @@ inline LogStreamConsumer LOG_ERROR(const Logger& logger)
 //!
 //!     LOG_FATAL(logger) << "hello world" << std::endl;
 //!
-inline LogStreamConsumer LOG_FATAL(const Logger& logger)
-{
+inline LogStreamConsumer LOG_FATAL(const Logger& logger) {
     return LogStreamConsumer(logger.getReportableSeverity(), Severity::kINTERNAL_ERROR);
 }
 
-} // anonymous namespace
+}  // anonymous namespace
 
-#endif // TENSORRT_LOGGING_H
+#endif  // TENSORRT_LOGGING_H

--- a/mobilenet/mobilenetv3/mobilenet_v3.py
+++ b/mobilenet/mobilenetv3/mobilenet_v3.py
@@ -4,7 +4,6 @@ import struct
 import argparse
 
 import numpy as np
-import pycuda.autoinit
 import pycuda.driver as cuda
 import tensorrt as trt
 
@@ -15,12 +14,39 @@ OUTPUT_SIZE = 1000
 BS = 1
 INPUT_BLOB_NAME = "data"
 OUTPUT_BLOB_NAME = "prob"
-EPS = 1e-5
-
-WEIGHT_PATH_SMALL = "./mobilenetv3.wts"
-ENGINE_PATH = "./mobilenetv3.engine"
+EPS = 1e-3
 
 TRT_LOGGER = trt.Logger(trt.Logger.INFO)
+
+
+def preprocess_image(img_path, h=INPUT_H, w=INPUT_W):
+    """
+    Returns np.float32 array of shape (1, 3, H, W), normalized like ImageNet.
+    Falls back to simple [0,1] if Pillow/OpenCV not available.
+    """
+    try:
+        import cv2
+        img = cv2.imread(img_path, cv2.IMREAD_COLOR)
+        if img is None:
+            raise RuntimeError(f"Failed to read image: {img_path}")
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        img = cv2.resize(img, (w, h), interpolation=cv2.INTER_LINEAR)
+        img = img.astype(np.float32) / 255.0
+    except Exception:
+        # Fallback to PIL
+        from PIL import Image
+        img = Image.open(img_path).convert("RGB").resize((w, h))
+        img = np.asarray(img, dtype=np.float32) / 255.0
+
+    # Imagenet normalization (same as common MobileNetV3 training)
+    mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+    std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+    img = (img - mean) / std
+
+    # HWC->CHW and add batch dim
+    img = np.transpose(img, (2, 0, 1))            # (3, H, W)
+    img = np.expand_dims(img, axis=0).copy()      # (1, 3, H, W)
+    return img
 
 
 def load_weights(file):
@@ -75,15 +101,14 @@ def add_h_swish(network, input):
 
 def conv_bn_h_swish(network, weight_map, input, outch, ksize, s, g, lname):
     p = (ksize - 1) // 2
-    conv1 = network.add_convolution(input=input,
-                                    num_output_maps=outch,
-                                    kernel_shape=(ksize, ksize),
-                                    kernel=weight_map[lname + "0.weight"],
-                                    bias=trt.Weights()
-                                    )
+    conv1 = network.add_convolution_nd(input=input,
+                                       num_output_maps=outch,
+                                       kernel_shape=(ksize, ksize),
+                                       kernel=weight_map[lname + "0.weight"],
+                                       bias=trt.Weights())
     assert conv1
-    conv1.stride = (s, s)
-    conv1.padding = (p, p)
+    conv1.stride_nd = (s, s)
+    conv1.padding_nd = (p, p)
     conv1.num_groups = g
 
     bn1 = add_batch_norm_2d(network, weight_map, conv1.get_output(0), lname + "1", EPS)
@@ -94,41 +119,67 @@ def conv_bn_h_swish(network, weight_map, input, outch, ksize, s, g, lname):
 
 
 def add_se_layer(network, weight_map, input, c, w, lname):
-    h = w
-    l1 = network.add_pooling(input=input,
-                             type=trt.PoolingType.AVERAGE,
-                             window_size=trt.DimsHW(w, h))
-    assert l1
-    l1.stride_nd = (w, h)
+    # Global average pool to (BS, C, 1, 1)
+    pool = network.add_pooling_nd(input=input,
+                                  type=trt.PoolingType.AVERAGE,
+                                  window_size=trt.DimsHW(w, w))
+    pool.stride_nd = (w, w)
 
-    l2 = network.add_fully_connected(input=l1.get_output(0),
-                                     num_outputs=BS * c // 4,
-                                     kernel=weight_map[lname + "fc.0.weight"],
-                                     bias=weight_map[lname + "fc.0.bias"])
-    relu1 = network.add_activation(l2.get_output(0), type=trt.ActivationType.RELU)
-    l4 = network.add_fully_connected(input=relu1.get_output(0),
-                                     num_outputs=BS * c,
-                                     kernel=weight_map[lname + "fc.2.weight"],
-                                     bias=weight_map[lname + "fc.2.bias"])
+    # Infer SE reduction channels from weights (do NOT assume c//4)
+    se_c = int(weight_map[lname + "fc1.bias"].size)
 
-    se = add_h_swish(network, l4.get_output(0))
+    # Flatten pooled tensor to (BS, C)
+    sh1 = network.add_shuffle(pool.get_output(0))
+    sh1.reshape_dims = (BS, c)
 
-    return se
+    # fc1: (BS, C) x (C, se_c) + b -> (BS, se_c)
+    w1 = weight_map[lname + "fc1.weight"].reshape(se_c, c, 1, 1).reshape(se_c, c)
+    b1 = weight_map[lname + "fc1.bias"].reshape(1, se_c)
+    k1 = network.add_constant((se_c, c), w1)
+    mm1 = network.add_matrix_multiply(sh1.get_output(0), trt.MatrixOperation.NONE,
+                                      k1.get_output(0), trt.MatrixOperation.TRANSPOSE)
+    add1 = network.add_elementwise(
+        mm1.get_output(0),
+        network.add_constant((1, se_c), b1).get_output(0),
+        trt.ElementWiseOperation.SUM
+    )
+    relu = network.add_activation(add1.get_output(0), trt.ActivationType.RELU)
+
+    # fc2: (BS, se_c) x (se_c, C) + b -> (BS, C)
+    w2 = weight_map[lname + "fc2.weight"].reshape(c, se_c, 1, 1).reshape(c, se_c)
+    b2 = weight_map[lname + "fc2.bias"].reshape(1, c)
+    k2 = network.add_constant((c, se_c), w2)
+    mm2 = network.add_matrix_multiply(relu.get_output(0), trt.MatrixOperation.NONE,
+                                      k2.get_output(0), trt.MatrixOperation.TRANSPOSE)
+    add2 = network.add_elementwise(
+        mm2.get_output(0),
+        network.add_constant((1, c), b2).get_output(0),
+        trt.ElementWiseOperation.SUM
+    )
+
+    # hard-sigmoid, then reshape to (BS, C, 1, 1) for channel-wise scaling
+    hsig = network.add_activation(add2.get_output(0), trt.ActivationType.HARD_SIGMOID)
+    hsig.alpha = 1.0 / 6.0
+    hsig.beta = 0.5
+    sh2 = network.add_shuffle(hsig.get_output(0))
+    sh2.reshape_dims = (BS, c, 1, 1)
+
+    return network.add_elementwise(input, sh2.get_output(0), trt.ElementWiseOperation.PROD)
 
 
 def conv_seq_1(network, weight_map, input, output, hdim, k, s, use_se, use_hs, w, lname):
     p = (k - 1) // 2
-    conv1 = network.add_convolution(input=input,
-                                    num_output_maps=hdim,
-                                    kernel_shape=(k, k),
-                                    kernel=weight_map[lname + "0.weight"],
-                                    bias=trt.Weights())
+    conv1 = network.add_convolution_nd(input=input,
+                                       num_output_maps=hdim,
+                                       kernel_shape=(k, k),
+                                       kernel=weight_map[lname + "0.0.weight"],
+                                       bias=trt.Weights())
     assert conv1
-    conv1.stride = (s, s)
-    conv1.padding = (p, p)
+    conv1.stride_nd = (s, s)
+    conv1.padding_nd = (p, p)
     conv1.num_groups = hdim
 
-    bn1 = add_batch_norm_2d(network, weight_map, conv1.get_output(0), lname + "1", EPS)
+    bn1 = add_batch_norm_2d(network, weight_map, conv1.get_output(0), lname + "0.1", EPS)
 
     if use_hs:
         hsw = add_h_swish(network, bn1.get_output(0))
@@ -138,17 +189,17 @@ def conv_seq_1(network, weight_map, input, output, hdim, k, s, use_se, use_hs, w
         tensor3 = relu1.get_output(0)
 
     if use_se:
-        se1 = add_se_layer(network, weight_map, tensor3, hdim, w, lname + "3.")
+        se1 = add_se_layer(network, weight_map, tensor3, hdim, w, lname + "1.")
         tensor4 = se1.get_output(0)
     else:
         tensor4 = tensor3
 
-    conv2 = network.add_convolution(input=tensor4,
-                                    num_output_maps=output,
-                                    kernel_shape=(1, 1),
-                                    kernel=weight_map[lname + "4.weight"],
-                                    bias=trt.Weights())
-    bn2 = add_batch_norm_2d(network, weight_map, conv2.get_output(0), lname + "5", EPS)
+    conv2 = network.add_convolution_nd(input=tensor4,
+                                       num_output_maps=output,
+                                       kernel_shape=(1, 1),
+                                       kernel=weight_map[lname + "2.0.weight"],
+                                       bias=trt.Weights())
+    bn2 = add_batch_norm_2d(network, weight_map, conv2.get_output(0), lname + "2.1", EPS)
     assert bn2
 
     return bn2
@@ -156,76 +207,106 @@ def conv_seq_1(network, weight_map, input, output, hdim, k, s, use_se, use_hs, w
 
 def conv_seq_2(network, weight_map, input, output, hdim, k, s, use_se, use_hs, w, lname):
     p = (k - 1) // 2
-    conv1 = network.add_convolution(input=input,
-                                    num_output_maps=hdim,
-                                    kernel_shape=(1, 1),
-                                    kernel=weight_map[lname + "0.weight"],
-                                    bias=trt.Weights())
-    bn1 = add_batch_norm_2d(network, weight_map, conv1.get_output(0), lname + "1", EPS)
+    conv1 = network.add_convolution_nd(input=input, num_output_maps=hdim,
+                                       kernel_shape=(1, 1),
+                                       kernel=weight_map[lname + "0.0.weight"],
+                                       bias=trt.Weights())
+    bn1 = add_batch_norm_2d(network, weight_map, conv1.get_output(0), lname + "0.1", EPS)
+    x = add_h_swish(network, bn1.get_output(0)).get_output(0) if use_hs else \
+        network.add_activation(bn1.get_output(0), trt.ActivationType.RELU).get_output(0)
 
-    if use_hs:
-        hsw1 = add_h_swish(network, bn1.get_output(0))
-        tensor3 = hsw1.get_output(0)
-    else:
-        relu1 = network.add_activation(bn1.get_output(0), type=trt.ActivationType.RELU)
-        tensor3 = relu1.get_output(0)
-
-    conv2 = network.add_convolution(input=tensor3,
-                                    num_output_maps=hdim,
-                                    kernel_shape=(k, k),
-                                    kernel=weight_map[lname + "3.weight"],
-                                    bias=trt.Weights())
-    conv2.stride = (s, s)
-    conv2.padding = (p, p)
+    conv2 = network.add_convolution_nd(input=x, num_output_maps=hdim,
+                                       kernel_shape=(k, k),
+                                       kernel=weight_map[lname + "1.0.weight"],
+                                       bias=trt.Weights())
+    conv2.stride_nd = (s, s)
+    conv2.padding_nd = (p, p)
     conv2.num_groups = hdim
-    bn2 = add_batch_norm_2d(network, weight_map, conv2.get_output(0), lname + "4", EPS)
+    bn2 = add_batch_norm_2d(network, weight_map, conv2.get_output(0), lname + "1.1", EPS)
+
+    x = add_h_swish(network, bn2.get_output(0)).get_output(0) if use_hs else \
+        network.add_activation(bn2.get_output(0), trt.ActivationType.RELU).get_output(0)
 
     if use_se:
-        se1 = add_se_layer(network, weight_map, bn2.get_output(0), hdim, w, lname + "5.")
-        tensor6 = se1.get_output(0)
-    else:
-        tensor6 = bn2.get_output(0)
+        x = add_se_layer(network, weight_map, x, hdim, w, lname + "2.").get_output(0)
+
+    proj_idx = "3." if use_se else "2."
+    conv3 = network.add_convolution_nd(input=x, num_output_maps=output,
+                                       kernel_shape=(1, 1),
+                                       kernel=weight_map[lname + proj_idx + "0.weight"],
+                                       bias=trt.Weights())
+    bn3 = add_batch_norm_2d(network, weight_map, conv3.get_output(0), lname + proj_idx + "1", EPS)
+    return bn3
+
+
+def conv_seq_0(network, weight_map, input, output, hdim, k, s, use_se, use_hs, w, lname):
+    # NO expansion, NO SE (e.g., MobileNetV3-Large features.1)
+    # lname is "...features.X.block."
+    p = (k - 1) // 2
+
+    # Depthwise conv + BN + act
+    conv1 = network.add_convolution_nd(
+        input=input,
+        num_output_maps=hdim,
+        kernel_shape=(k, k),
+        kernel=weight_map[lname + "0.0.weight"],
+        bias=trt.Weights(),
+    )
+    conv1.stride_nd = (s, s)
+    conv1.padding_nd = (p, p)
+    conv1.num_groups = hdim
+
+    bn1 = add_batch_norm_2d(network, weight_map, conv1.get_output(0), lname + "0.1", EPS)
 
     if use_hs:
-        hsw2 = add_h_swish(network, tensor6)
-        tensor7 = hsw2.get_output(0)
+        x = add_h_swish(network, bn1.get_output(0)).get_output(0)
     else:
-        relu2 = network.add_activation(tensor6, type=trt.ActivationType.RELU)
-        tensor7 = relu2.get_output(0)
+        x = network.add_activation(bn1.get_output(0), type=trt.ActivationType.RELU).get_output(0)
 
-    conv3 = network.add_convolution(input=tensor7,
-                                    num_output_maps=output,
-                                    kernel_shape=(1, 1),
-                                    kernel=weight_map[lname + "7.weight"],
-                                    bias=trt.Weights())
-    bn3 = add_batch_norm_2d(network, weight_map, conv3.get_output(0), lname + "8", EPS)
-    assert bn3
+    # Pointwise projection + BN
+    conv2 = network.add_convolution_nd(
+        input=x,
+        num_output_maps=output,
+        kernel_shape=(1, 1),
+        kernel=weight_map[lname + "1.0.weight"],
+        bias=trt.Weights(),
+    )
+    bn2 = add_batch_norm_2d(network, weight_map, conv2.get_output(0), lname + "1.1", EPS)
+    assert bn2
 
-    return bn3
+    return bn2
 
 
 def inverted_res(network, weight_map, input, lname, inch, outch, s, hidden, k, use_se, use_hs, w):
     use_res_connect = (s == 1 and inch == outch)
 
     if inch == hidden:
-        conv = conv_seq_1(network, weight_map, input, outch, hidden, k, s, use_se, use_hs, w, lname + "conv.")
+        if use_se:
+            # depthwise (+ optional SE) -> projection
+            conv = conv_seq_1(network, weight_map, input, outch, hidden, k, s, use_se, use_hs, w, lname + "block.")
+        else:
+            # NO expansion, NO SE  (MobileNetV3-Large features.1 etc.)
+            conv = conv_seq_0(network, weight_map, input, outch, hidden, k, s, use_se, use_hs, w, lname + "block.")
     else:
-        conv = conv_seq_2(network, weight_map, input, outch, hidden, k, s, use_se, use_hs, w, lname + "conv.")
+        # expansion -> depthwise (+ optional SE) -> projection
+        conv = conv_seq_2(network, weight_map, input, outch, hidden, k, s, use_se, use_hs, w, lname + "block.")
 
     if not use_res_connect:
         return conv
 
     ew3 = network.add_elementwise(input, conv.get_output(0), trt.ElementWiseOperation.SUM)
     assert ew3
-
     return ew3
 
 
 def create_engine_small(max_batch_size, builder, config, dt):
-    weight_map = load_weights(WEIGHT_PATH_SMALL)
-    network = builder.create_network()
+    weight_map = load_weights("./mbv3_small.wts")
 
-    data = network.add_input(INPUT_BLOB_NAME, dt, (3, INPUT_H, INPUT_W))
+    # TensorRT 10: Use explicit batch dimension
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+
+    # TensorRT 10: Input with explicit batch dimension
+    data = network.add_input(INPUT_BLOB_NAME, dt, (max_batch_size, 3, INPUT_H, INPUT_W))
     assert data
 
     ew1 = conv_bn_h_swish(network, weight_map, data, 16, 3, 2, 1, "features.0.")
@@ -240,50 +321,55 @@ def create_engine_small(max_batch_size, builder, config, dt):
     ir9 = inverted_res(network, weight_map, ir8.get_output(0), "features.9.", 48, 96, 2, 288, 5, 1, 1, 7)
     ir10 = inverted_res(network, weight_map, ir9.get_output(0), "features.10.", 96, 96, 1, 576, 5, 1, 1, 7)
     ir11 = inverted_res(network, weight_map, ir10.get_output(0), "features.11.", 96, 96, 1, 576, 5, 1, 1, 7)
-    ew2 = conv_bn_h_swish(network, weight_map, ir11.get_output(0), 576, 1, 1, 1, "conv.0.")
-    se1 = add_se_layer(network, weight_map, ew2.get_output(0), 576, 7, "conv.1.")
+    ew2 = conv_bn_h_swish(network, weight_map, ir11.get_output(0), 576, 1, 1, 1, "features.12.")
 
-    pool1 = network.add_pooling(input=se1.get_output(0),
-                                type=trt.PoolingType.AVERAGE,
-                                window_size=trt.DimsHW(7, 7))
-    assert pool1
-    pool1.stride_nd = (7, 7)
-    sw1 = add_h_swish(network, pool1.get_output(0))
+    pool1 = network.add_pooling_nd(input=ew2.get_output(0),
+                                   type=trt.PoolingType.AVERAGE,
+                                   window_size=trt.DimsHW(7, 7))
+    # Flatten to (N, 576)
+    reshape1 = network.add_shuffle(pool1.get_output(0))
+    reshape1.reshape_dims = (max_batch_size, 576)
 
-    fc1 = network.add_fully_connected(input=sw1.get_output(0),
-                                      num_outputs=1280,
-                                      kernel=weight_map["classifier.0.weight"],
-                                      bias=weight_map["classifier.0.bias"])
-    assert fc1
-    bn1 = add_batch_norm_2d(network, weight_map, fc1.get_output(0), "classifier.1", EPS)
-    sw2 = add_h_swish(network, bn1.get_output(0))
+    # FCs via MatrixMultiply + bias (like C++)
+    fc1_w = weight_map["classifier.0.weight"].reshape(1024, 576)
+    fc1_b = weight_map["classifier.0.bias"].reshape(1, 1024)
+    k1 = network.add_constant((1024, 576), fc1_w)
+    mm1 = network.add_matrix_multiply(reshape1.get_output(0), trt.MatrixOperation.NONE,
+                                      k1.get_output(0), trt.MatrixOperation.TRANSPOSE)
+    b1 = network.add_constant((1, 1024), fc1_b)
+    add1 = network.add_elementwise(mm1.get_output(0), b1.get_output(0), trt.ElementWiseOperation.SUM)
 
-    fc2 = network.add_fully_connected(input=sw2.get_output(0),
-                                      num_outputs=OUTPUT_SIZE,
-                                      kernel=weight_map["classifier.3.weight"],
-                                      bias=weight_map["classifier.3.bias"])
-    bn2 = add_batch_norm_2d(network, weight_map, fc2.get_output(0), "classifier.4", EPS)
-    sw3 = add_h_swish(network, bn2.get_output(0))
+    hsw = add_h_swish(network, add1.get_output(0))
 
-    sw3.get_output(0).name = OUTPUT_BLOB_NAME
-    network.mark_output(sw3.get_output(0))
+    fc2_w = weight_map["classifier.3.weight"].reshape(1000, 1024)
+    fc2_b = weight_map["classifier.3.bias"].reshape(1, 1000)
+    k2 = network.add_constant((1000, 1024), fc2_w)
+    mm2 = network.add_matrix_multiply(hsw.get_output(0), trt.MatrixOperation.NONE,
+                                      k2.get_output(0), trt.MatrixOperation.TRANSPOSE)
+    b2 = network.add_constant((1, 1000), fc2_b)
+    add2 = network.add_elementwise(mm2.get_output(0), b2.get_output(0), trt.ElementWiseOperation.SUM)
 
-    # Build Engine
-    builder.max_batch_size = max_batch_size
-    builder.max_workspace_size = 1 << 20
-    engine = builder.build_engine(network, config)
+    add2.get_output(0).name = OUTPUT_BLOB_NAME
+    network.mark_output(add2.get_output(0))
+
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
+
+    serialized_engine = builder.build_serialized_network(network, config)
 
     del network
     del weight_map
 
-    return engine
+    return serialized_engine
 
 
 def create_engine_large(max_batch_size, builder, config, dt):
-    weight_map = load_weights(WEIGHT_PATH_SMALL)
-    network = builder.create_network()
+    weight_map = load_weights("./mbv3_large.wts")
 
-    data = network.add_input(INPUT_BLOB_NAME, dt, (3, INPUT_H, INPUT_W))
+    # TensorRT 10: Use explicit batch dimension
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+
+    # TensorRT 10: Input with explicit batch dimension
+    data = network.add_input(INPUT_BLOB_NAME, dt, (max_batch_size, 3, INPUT_H, INPUT_W))
     assert data
 
     ew1 = conv_bn_h_swish(network, weight_map, data, 16, 3, 2, 1, "features.0.")
@@ -299,58 +385,88 @@ def create_engine_large(max_batch_size, builder, config, dt):
     ir10 = inverted_res(network, weight_map, ir9.get_output(0), "features.10.", 80, 80, 1, 184, 3, 0, 1, 14)
     ir11 = inverted_res(network, weight_map, ir10.get_output(0), "features.11.", 80, 112, 1, 480, 3, 1, 1, 14)
     ir12 = inverted_res(network, weight_map, ir11.get_output(0), "features.12.", 112, 112, 1, 672, 3, 1, 1, 14)
-    ir13 = inverted_res(network, weight_map, ir12.get_output(0), "features.13.", 112, 160, 1, 672, 5, 1, 1, 14)
-    ir14 = inverted_res(network, weight_map, ir13.get_output(0), "features.14.", 160, 160, 2, 672, 5, 1, 1, 7)
+    ir13 = inverted_res(network, weight_map, ir12.get_output(0), "features.13.", 112, 160, 2, 672, 5, 1, 1, 7)
+    ir14 = inverted_res(network, weight_map, ir13.get_output(0), "features.14.", 160, 160, 1, 960, 5, 1, 1, 7)
     ir15 = inverted_res(network, weight_map, ir14.get_output(0), "features.15.", 160, 160, 1, 960, 5, 1, 1, 7)
-    ew2 = conv_bn_h_swish(network, weight_map, ir15.get_output(0), 960, 1, 1, 1, "conv.0.")
+    ew2 = conv_bn_h_swish(network, weight_map, ir15.get_output(0), 960, 1, 1, 1, "features.16.")
 
-    pool1 = network.add_pooling(input=ew2.get_output(0),
-                                type=trt.PoolingType.AVERAGE,
-                                window_size=trt.DimsHW(7, 7))
+    pool1 = network.add_pooling_nd(input=ew2.get_output(0),
+                                   type=trt.PoolingType.AVERAGE,
+                                   window_size=trt.DimsHW(7, 7))
     assert pool1
-    pool1.stride_nd = (7, 7)
-    sw1 = add_h_swish(network, pool1.get_output(0))
+    pool1.stride_nd = trt.DimsHW(7, 7)
 
-    fc1 = network.add_fully_connected(input=sw1.get_output(0),
-                                      num_outputs=1280,
-                                      kernel=weight_map["classifier.0.weight"],
-                                      bias=weight_map["classifier.0.bias"])
+    # TensorRT 10: Alternative approach using MatrixMultiply for fully connected layer
+    # Reshape pooled output to 2D
+    input_reshape = network.add_shuffle(pool1.get_output(0))
+    input_reshape.reshape_dims = (max_batch_size, 960)
+
+    # Add weight as constant layer
+    fc_weights = weight_map["classifier.0.weight"].reshape(1280, 960)
+    filter_const = network.add_constant((1280, 960), fc_weights)
+
+    # Matrix multiplication
+    mm = network.add_matrix_multiply(input_reshape.get_output(0), trt.MatrixOperation.NONE,
+                                     filter_const.get_output(0), trt.MatrixOperation.TRANSPOSE)
+
+    # Add bias
+    bias_weights = weight_map["classifier.0.bias"].reshape(1, 1280)
+    bias_const = network.add_constant((1, 1280), bias_weights)
+
+    fc1 = network.add_elementwise(mm.get_output(0), bias_const.get_output(0), trt.ElementWiseOperation.SUM)
     assert fc1
+
     sw2 = add_h_swish(network, fc1.get_output(0))
 
-    fc2 = network.add_fully_connected(input=sw2.get_output(0),
-                                      num_outputs=OUTPUT_SIZE,
-                                      kernel=weight_map["classifier.3.weight"],
-                                      bias=weight_map["classifier.3.bias"])
+    # Second fully connected layer
+    input_reshape2 = network.add_shuffle(sw2.get_output(0))
+    input_reshape2.reshape_dims = (max_batch_size, 1280)
+
+    fc2_weights = weight_map["classifier.3.weight"].reshape(OUTPUT_SIZE, 1280)
+    filter_const2 = network.add_constant((OUTPUT_SIZE, 1280), fc2_weights)
+
+    mm2 = network.add_matrix_multiply(input_reshape2.get_output(0), trt.MatrixOperation.NONE,
+                                      filter_const2.get_output(0), trt.MatrixOperation.TRANSPOSE)
+
+    bias2_weights = weight_map["classifier.3.bias"].reshape(1, OUTPUT_SIZE)
+    bias_const2 = network.add_constant((1, OUTPUT_SIZE), bias2_weights)
+
+    fc2 = network.add_elementwise(mm2.get_output(0), bias_const2.get_output(0), trt.ElementWiseOperation.SUM)
+    assert fc2
 
     fc2.get_output(0).name = OUTPUT_BLOB_NAME
     network.mark_output(fc2.get_output(0))
 
-    # Build Engine
-    builder.max_batch_size = max_batch_size
-    builder.max_workspace_size = 1 << 20
-    engine = builder.build_engine(network, config)
+    # TensorRT 10: Updated builder configuration
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
+
+    # TensorRT 10: Use serialize_network instead of build_engine
+    serialized_engine = builder.build_serialized_network(network, config)
 
     del network
     del weight_map
 
-    return engine
+    return serialized_engine
 
 
 def API_to_model(max_batch_size, model_type):
     builder = trt.Builder(TRT_LOGGER)
     config = builder.create_builder_config()
+
     if model_type == "small":
-        engine = create_engine_small(max_batch_size, builder, config, trt.float32)
-        assert engine
+        serialized_engine = create_engine_small(max_batch_size, builder, config, trt.float32)
+        engine_path = "./mobilenetv3_small.plan"
     else:
-        engine = create_engine_large(max_batch_size, builder, config, trt.float32)
-        assert engine
+        serialized_engine = create_engine_large(max_batch_size, builder, config, trt.float32)
+        engine_path = "./mobilenetv3_large.plan"
 
-    with open(ENGINE_PATH, "wb") as f:
-        f.write(engine.serialize())
+    assert serialized_engine
+    with open(engine_path, "wb") as f:
+        f.write(serialized_engine)
 
-    del engine
+    print(f"Model serialized successfully to {engine_path}")
+
+    del serialized_engine
     del builder
     del config
 
@@ -367,72 +483,136 @@ class HostDeviceMem(object):
         return self.__str__()
 
 
-def allocate_buffers(engine):
+def allocate_buffers(engine, context):
+    """TensorRT 10 compatible buffer allocation"""
     inputs = []
     outputs = []
-    bindings = []
     stream = cuda.Stream()
-    for binding in engine:
-        size = trt.volume(engine.get_binding_shape(binding)) * engine.max_batch_size
-        dtype = trt.nptype(engine.get_binding_dtype(binding))
+
+    for i in range(engine.num_io_tensors):
+        tensor_name = engine.get_tensor_name(i)
+        tensor_mode = engine.get_tensor_mode(tensor_name)
+        tensor_dtype = engine.get_tensor_dtype(tensor_name)
+        tensor_shape = context.get_tensor_shape(tensor_name)
+
+        size = trt.volume(tensor_shape)
+        dtype = trt.nptype(tensor_dtype)
+
         # Allocate host and device buffers
         host_mem = cuda.pagelocked_empty(size, dtype)
         device_mem = cuda.mem_alloc(host_mem.nbytes)
-        # Append the device buffer to device bindings.
-        bindings.append(int(device_mem))
-        # Append to the appropriate list.
-        if engine.binding_is_input(binding):
+
+        # Set tensor address
+        context.set_tensor_address(tensor_name, int(device_mem))
+
+        # Append to the appropriate list
+        if tensor_mode == trt.TensorIOMode.INPUT:
             inputs.append(HostDeviceMem(host_mem, device_mem))
         else:
             outputs.append(HostDeviceMem(host_mem, device_mem))
-    return inputs, outputs, bindings, stream
+
+    return inputs, outputs, stream
 
 
-def do_inference(context, bindings, inputs, outputs, stream, batch_size=1):
-    # Transfer input data to the GPU.
+def do_inference(context, inputs, outputs, stream):
+    """TensorRT 10 compatible inference"""
+    # Transfer input data to the GPU
     [cuda.memcpy_htod_async(inp.device, inp.host, stream) for inp in inputs]
-    # Run inference.
-    context.execute_async(batch_size=batch_size, bindings=bindings, stream_handle=stream.handle)
-    # Transfer predictions back from the GPU.
+
+    # Run inference using TensorRT 10 API
+    context.execute_async_v3(stream_handle=stream.handle)
+
+    # Transfer predictions back from the GPU
     [cuda.memcpy_dtoh_async(out.host, out.device, stream) for out in outputs]
+
     # Synchronize the stream
     stream.synchronize()
-    # Return only the host outputs.
+
+    # Return only the host outputs
     return [out.host for out in outputs]
+
+
+def softmax(x):
+    e_x = np.exp(x - np.max(x))
+    return e_x / e_x.sum()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-s", action='store_true')
-    parser.add_argument("-d", action='store_true')
-    parser.add_argument("-t", help='indicate small or large model')
+    parser.add_argument("-s", action='store_true', help="serialize model to plan file")
+    parser.add_argument("-d", action='store_true', help="deserialize plan file and run inference")
+    parser.add_argument("model_type", choices=["small", "large"], help="Model variant (small or large)")
+    parser.add_argument("--image", default=None, type=str, help="Image to run inference.")
     args = parser.parse_args()
 
     if not (args.s ^ args.d):
         print(
-            "arguments not right!\n"
-            "python mobilenet_v2.py -s   # serialize model to plan file\n"
-            "python mobilenet_v2.py -d   # deserialize plan file and run inference"
+            "Usage: python mobilenet_v3.py <-s|-d> <small|large>\n"
+            "  -s small/large  : serialize model to plan file\n"
+            "  -d small/large  : deserialize plan file and run inference\n"
+            "\n"
+            "Examples:\n"
+            "  python mobilenet_v3.py -s large  # Build MobileNetV3-Large engine\n"
+            "  python mobilenet_v3.py -d large  # Run inference with all-ones test\n"
+            "  python mobilenet_v3.py -d small  # Run inference with MobileNetV3-Small\n"
+            "  python mobilenet_v3.py -d small  --image ../image.jpg # Run inference with MobileNetV3-Small on a image"
+
         )
         sys.exit()
 
     if args.s:
-        API_to_model(BATCH_SIZE, args.t)
+        API_to_model(BATCH_SIZE, args.model_type)
     else:
-        runtime = trt.Runtime(TRT_LOGGER)
-        assert runtime
+        engine_path = f"./mobilenetv3_{args.model_type}.plan"
 
-        with open(ENGINE_PATH, "rb") as f:
+        if not os.path.exists(engine_path):
+            print(f"Engine file {engine_path} not found. Please run with -s first to build the engine.")
+            sys.exit(1)
+
+        runtime = trt.Runtime(TRT_LOGGER)
+        with open(engine_path, "rb") as f:
             engine = runtime.deserialize_cuda_engine(f.read())
         assert engine
 
         context = engine.create_execution_context()
         assert context
 
-        data = np.ones((BATCH_SIZE * 3 * INPUT_H * INPUT_W), dtype=np.float32)
-        inputs, outputs, bindings, stream = allocate_buffers(engine)
-        inputs[0].host = data
+        # load image or fall back to ones
+        if "--image" in sys.argv or any(a.startswith("--image") for a in sys.argv):
+            # arg already declared in argparse; use it
+            if args.image and os.path.exists(args.image):
+                host_input = preprocess_image(args.image)  # (1,3,H,W)
+                print(f"Using image: {args.image}")
+            else:
+                print("Image not found, using all-ones test data")
+                host_input = np.ones((BATCH_SIZE, 3, INPUT_H, INPUT_W), dtype=np.float32)
+        else:
+            host_input = np.ones((BATCH_SIZE, 3, INPUT_H, INPUT_W), dtype=np.float32)
+            print("No image provided, using all-ones test data")
 
-        trt_outputs = do_inference(context, bindings=bindings, inputs=inputs, outputs=outputs, stream=stream)
+        context.set_input_shape(INPUT_BLOB_NAME, (BATCH_SIZE, 3, INPUT_H, INPUT_W))
 
-        print(f'Output: \n{trt_outputs[0][:10]}\n{trt_outputs[0][-10:]}')
+        # allocate host/device buffers and bind them to the context
+        inputs, outputs, stream = allocate_buffers(engine, context)
+
+        # populate input host buffer (flatten to match binding size)
+        inputs[0].host[:] = host_input.ravel()
+
+        # run inference (this does H2D, enqueue_v3, D2H, sync)
+        trt_outputs = do_inference(context, inputs=inputs, outputs=outputs, stream=stream)
+
+        logits = trt_outputs[0].reshape(BATCH_SIZE, OUTPUT_SIZE)[0]
+        probs = softmax(logits)
+
+        if args.image:
+            top5_idx = probs.argsort()[-5:][::-1]
+            print("\nTop-5 classes:")
+            for i in top5_idx:
+                print(f"{i:4d}: {probs[i]:.4f}")
+        else:
+            print(f'Output: \n{trt_outputs[0][:10]}\n{trt_outputs[0][-10:]}')
+
+        # Cleanup
+        del context
+        del engine
+        del runtime

--- a/mobilenet/mobilenetv3/utils.h
+++ b/mobilenet/mobilenetv3/utils.h
@@ -1,0 +1,109 @@
+#ifndef MOBILENET_UTILS_H
+#define MOBILENET_UTILS_H
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <opencv2/opencv.hpp>
+#include <string>
+#include <vector>
+
+#define INPUT_H 224
+#define INPUT_W 224
+
+/**
+ * Preprocesses an image using the standard PyTorch MobileNet preprocessing pipeline:
+ * 1. Load image and convert BGR to RGB
+ * 2. Resize to 256x256
+ * 3. Center crop to 224x224
+ * 4. Convert to float [0,1] (ToTensor equivalent)
+ * 5. Normalize with ImageNet stats: mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+ *
+ * @param imagePath Path to input image file
+ * @return Preprocessed image data as CHW float vector
+ */
+std::vector<float> preprocessImage(const std::string& imagePath) {
+    cv::Mat image = cv::imread(imagePath);
+    if (image.empty()) {
+        std::cerr << "Error: Could not load image: " << imagePath << std::endl;
+        exit(1);
+    }
+
+    std::cout << "Original image size: " << image.cols << "x" << image.rows << std::endl;
+
+    // Convert BGR to RGB
+    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+
+    // PyTorch preprocessing: Resize to 256, then center crop to 224
+    int resize_size = 256;
+    cv::resize(image, image, cv::Size(resize_size, resize_size));
+
+    // Center crop to 224x224
+    int crop_size = 224;
+    int start_x = (resize_size - crop_size) / 2;
+    int start_y = (resize_size - crop_size) / 2;
+    cv::Rect crop_rect(start_x, start_y, crop_size, crop_size);
+    image = image(crop_rect);
+
+    // Convert to float and normalize to [0, 1] (ToTensor equivalent)
+    image.convertTo(image, CV_32F, 1.0 / 255.0);
+
+    // ImageNet normalization: mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+    std::vector<float> mean = {0.485f, 0.456f, 0.406f};
+    std::vector<float> std = {0.229f, 0.224f, 0.225f};
+
+    std::vector<float> input_data(3 * INPUT_H * INPUT_W);
+
+    for (int c = 0; c < 3; c++) {
+        for (int h = 0; h < INPUT_H; h++) {
+            for (int w = 0; w < INPUT_W; w++) {
+                int dst_idx = c * INPUT_H * INPUT_W + h * INPUT_W + w;
+                float pixel_value = image.at<cv::Vec3f>(h, w)[c];
+                input_data[dst_idx] = (pixel_value - mean[c]) / std[c];
+            }
+        }
+    }
+
+    return input_data;
+}
+
+/**
+ * Applies softmax to output logits and prints top-k predictions
+ *
+ * @param output Raw model output logits
+ * @param output_size Size of output array
+ * @param k Number of top predictions to print
+ */
+void printTopPredictions(float* output, int output_size, int k = 5) {
+    std::vector<float> softmax_output(output_size);
+    float max_val = *std::max_element(output, output + output_size);
+
+    float sum_exp = 0.0f;
+    for (int i = 0; i < output_size; i++) {
+        softmax_output[i] = std::exp(output[i] - max_val);
+        sum_exp += softmax_output[i];
+    }
+
+    for (int i = 0; i < output_size; i++) {
+        softmax_output[i] /= sum_exp;
+    }
+
+    std::vector<std::pair<float, int>> prob_index_pairs;
+    for (int i = 0; i < output_size; i++) {
+        prob_index_pairs.push_back({softmax_output[i], i});
+    }
+
+    std::sort(prob_index_pairs.begin(), prob_index_pairs.end(),
+              [](const std::pair<float, int>& a, const std::pair<float, int>& b) { return a.first > b.first; });
+
+    std::cout << "\nTop " << k << " predictions:" << std::endl;
+    for (int i = 0; i < k && i < output_size; i++) {
+        std::cout << "  " << i + 1 << ". Class " << prob_index_pairs[i].second << ": " << prob_index_pairs[i].first
+                  << std::endl;
+    }
+
+    std::cout << std::endl;
+}
+
+#endif  // MOBILENET_UTILS_H


### PR DESCRIPTION
Only upgrading mobilenetv3 instead of both mobilenetv2/v3 as in PR #1707 

**C++ Implementations**

  - Replaced deprecated APIs:
    - `IBuilder::buildEngineWithConfig()` -> `IBuilder::buildSerializedNetwork()`
    - `ICudaEngine::deserialize()` -> `IRuntime::deserializeCudaEngine()` with custom `IStreamReaderV2`
    - `IExecutionContext::execute()` -> `IExecutionContext::enqueueV3()`
  - Implemented `MyStreamReaderV2` class for TensorRT 10 engine deserialization
  - Updated inference pipeline to use `setTensorAddress()` and modern execution API
  
**Python Implementations**

  - Replaced `build_engine()` -> `build_serialized_network()`
  - Updated to explicit batch mode with `NetworkDefinitionCreationFlag.EXPLICIT_BATCH`
  - Replaced deprecated `add_fully_connected()` with `add_matrix_multiply()
  - Updated buffer allocation to use TensorRT 10 tensor API `(get_tensor_name(), set_tensor_address(), etc.)`
  - Migrated to `execute_async_v3()` for inference

Other Improvements

  - Updated README files with correct script names and output file names
  - Added utils.h for image preprocessing pipeline
  
*Output Sanity Check agains pytorchx:*
mobilenetv3-small:
```
pytorchx: -3.4606e-03, -1.2621e-01,  2.3399e-01, -1.2450e-01,  2.7816e-01
tensorrtx: 0.0197003, -0.112725, 0.211143, -0.124036, 0.288239
```

mobilenetv3-large
```
pytorchx: -5.2233e-01,  7.0307e-01,  1.2416e+00,  6.9224e-01,  1.4927e+00
tensorrtx: -0.536705, 0.708078, 1.24243, 0.717128, 1.50676
```